### PR TITLE
feat: Take MongoDB connection arguments separately

### DIFF
--- a/chart/templates/cogrpc-deploy.yml
+++ b/chart/templates/cogrpc-deploy.yml
@@ -49,6 +49,8 @@ spec:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}-generated
+            - configMapRef:
+                name: {{ include "relaynet-internet-gateway.fullname" . }}-mongo
             - secretRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
           ports:

--- a/chart/templates/crcin-deploy.yml
+++ b/chart/templates/crcin-deploy.yml
@@ -41,6 +41,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
+            - configMapRef:
+                name: {{ include "relaynet-internet-gateway.fullname" . }}-mongo
             - secretRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
           resources:

--- a/chart/templates/global-secret.yml
+++ b/chart/templates/global-secret.yml
@@ -4,6 +4,6 @@ metadata:
   name: {{ include "relaynet-internet-gateway.fullname" . }}
 type: Opaque
 data:
-  MONGO_URI: {{ .Values.mongo.uri | b64enc }}
+  MONGO_PASSWORD: {{ .Values.mongo.password | b64enc }}
 
   VAULT_TOKEN: {{ .Values.vault.token | b64enc }}

--- a/chart/templates/keygen-job.yml
+++ b/chart/templates/keygen-job.yml
@@ -34,5 +34,7 @@ spec:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}-generated
+            - configMapRef:
+                name: {{ include "relaynet-internet-gateway.fullname" . }}-mongo
             - secretRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}

--- a/chart/templates/mongo-cm.yml
+++ b/chart/templates/mongo-cm.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "relaynet-internet-gateway.fullname" . }}-mongo
+data:
+  MONGO_URI: {{ .Values.mongo.uri }}
+  MONGO_DB: {{ .Values.mongo.db }}
+  MONGO_USER: {{ .Values.mongo.user }}

--- a/chart/templates/pdcout-deploy.yml
+++ b/chart/templates/pdcout-deploy.yml
@@ -43,6 +43,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
+            - configMapRef:
+                name: {{ include "relaynet-internet-gateway.fullname" . }}-mongo
             - secretRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
           resources:

--- a/chart/templates/pohttp-deploy.yml
+++ b/chart/templates/pohttp-deploy.yml
@@ -43,6 +43,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
+            - configMapRef:
+                name: {{ include "relaynet-internet-gateway.fullname" . }}-mongo
             - secretRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
           ports:

--- a/chart/templates/poweb-deploy.yml
+++ b/chart/templates/poweb-deploy.yml
@@ -45,6 +45,8 @@ spec:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}-generated
+            - configMapRef:
+                name: {{ include "relaynet-internet-gateway.fullname" . }}-mongo
             - secretRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}
           ports:

--- a/chart/values.dev.yml
+++ b/chart/values.dev.yml
@@ -18,7 +18,10 @@ pdcQueue:
   replicaCount: 2
 
 mongo:
-  uri: mongodb://mongodb/test_db
+  uri: mongodb://mongodb
+  db: gw
+  user: root
+  password: letmein
 
 nats:
   nameOverride: nats
@@ -64,7 +67,7 @@ minio:
 mongodb:
   fullnameOverride: mongodb
   auth:
-    enabled: false
+    rootPassword: letmein
   persistence:
     enabled: false
 

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -87,13 +87,20 @@
     },
     "mongo": {
       "type": "object",
-      "required": [
-        "uri"
-      ],
+      "required": ["uri", "db", "user", "password"],
       "properties": {
         "uri": {
           "type": "string",
           "format": "uri"
+        },
+        "db": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
         }
       }
     },

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,10 @@ cogrpcHost: gogrpc.eu.relaycorp.tech
 pohttpHost: pohttp.eu.relaycorp.tech
 powebHost: poweb.eu.relaycorp.tech
 mongo:
-  uri: mongodb+srv://user:password@foo.gcp.mongodb.net/db
+  uri: mongodb+srv://foo.gcp.mongodb.net
+  db: db
+  user: the_user
+  password: passw0rd
 nats:
   serverUrl: nats://nats.example.com:4222
   clusterId: example-stan
@@ -60,6 +63,9 @@ Check out [`relaycorp/cloud-gateway`](https://github.com/relaycorp/cloud-gateway
 | `powebHost` | string | | Domain name for the PoWeb service |
 | `pdcQueue.replicaCount` | number | 3 | Number of workers (pods) for the PDC queue |
 | `mongo.uri` | string | | Connection URI for MongoDB |
+| `mongo.db` | string | | MongoDB database name |
+| `mongo.user` | string | | MongoDB user name |
+| `mongo.password` | string | | MongoDB user password |
 | `nats.serverUrl` | string | | Connection URI for NATS Streaming |
 | `nats.clusterId` | string | | NATS Streaming cluster id |
 | `objectStore.endpoint` | string | | Host name and port number for the object store server |

--- a/src/_test_utils.ts
+++ b/src/_test_utils.ts
@@ -6,6 +6,13 @@ import split2 from 'split2';
 
 export const UUID4_REGEX = expect.stringMatching(/^[0-9a-f-]+$/);
 
+export const MONGO_ENV_VARS = {
+  MONGO_DB: 'the_db',
+  MONGO_PASSWORD: 'letmein',
+  MONGO_URI: 'mongodb://example.com',
+  MONGO_USER: 'alicia',
+};
+
 export async function* arrayToAsyncIterable<T>(array: readonly T[]): AsyncIterable<T> {
   for (const item of array) {
     yield item;

--- a/src/backingServices/mongo.spec.ts
+++ b/src/backingServices/mongo.spec.ts
@@ -1,9 +1,9 @@
 import { EnvVarError } from 'env-var';
 import mongoose from 'mongoose';
 
-import { mockSpy } from '../_test_utils';
+import { mockSpy, MONGO_ENV_VARS } from '../_test_utils';
 import { configureMockEnvVars } from '../services/_test_utils';
-import { createMongooseConnectionFromEnv } from './mongo';
+import { createMongooseConnectionFromEnv, getMongooseConnectionArgsFromEnv } from './mongo';
 
 const MOCK_MONGOOSE_CONNECTION = { what: 'The connection' };
 const MOCK_MONGOOSE_CREATE_CONNECTION = mockSpy(
@@ -11,21 +11,87 @@ const MOCK_MONGOOSE_CREATE_CONNECTION = mockSpy(
   jest.fn().mockResolvedValue(MOCK_MONGOOSE_CONNECTION),
 );
 
-const MONGO_URI = 'mongodb://example.com';
+const mockEnvVars = configureMockEnvVars(MONGO_ENV_VARS);
 
-const mockEnvVars = configureMockEnvVars({ MONGO_URI });
+describe('getMongooseConnectionArgsFromEnv', () => {
+  test.each(Object.getOwnPropertyNames(MONGO_ENV_VARS))(
+    'Environment variable %s should be present',
+    (envVarName) => {
+      mockEnvVars({ ...MONGO_ENV_VARS, [envVarName]: undefined });
+
+      expect(getMongooseConnectionArgsFromEnv).toThrow(EnvVarError);
+    },
+  );
+
+  test('Connection should use MONGO_URI', () => {
+    expect(getMongooseConnectionArgsFromEnv().uri).toEqual(MONGO_ENV_VARS.MONGO_URI);
+  });
+
+  test('Connection should use MONGO_DB', () => {
+    expect(getMongooseConnectionArgsFromEnv().options.dbName).toEqual(MONGO_ENV_VARS.MONGO_DB);
+  });
+
+  test('Connection should use MONGO_USER', () => {
+    expect(getMongooseConnectionArgsFromEnv().options.user).toEqual(MONGO_ENV_VARS.MONGO_USER);
+  });
+
+  test('Connection should use MONGO_PASSWORD', () => {
+    expect(getMongooseConnectionArgsFromEnv().options.pass).toEqual(MONGO_ENV_VARS.MONGO_PASSWORD);
+  });
+
+  test('Connection should be created with new URL parser', () => {
+    expect(getMongooseConnectionArgsFromEnv().options.useNewUrlParser).toBeTrue();
+  });
+
+  test('Connection should use unified topology', () => {
+    expect(getMongooseConnectionArgsFromEnv().options.useUnifiedTopology).toBeTrue();
+  });
+});
 
 describe('createMongooseConnectionFromEnv', () => {
-  test('Environment variable MONGO_URI should be present', async () => {
-    mockEnvVars({ MONGO_URI: undefined });
+  test.each(Object.getOwnPropertyNames(MONGO_ENV_VARS))(
+    'Environment variable %s should be present',
+    async (envVarName) => {
+      mockEnvVars({ ...MONGO_ENV_VARS, [envVarName]: undefined });
 
-    await expect(createMongooseConnectionFromEnv()).rejects.toBeInstanceOf(EnvVarError);
-  });
+      await expect(createMongooseConnectionFromEnv()).rejects.toBeInstanceOf(EnvVarError);
+    },
+  );
 
   test('Connection should use MONGO_URI', async () => {
     await createMongooseConnectionFromEnv();
 
-    expect(MOCK_MONGOOSE_CREATE_CONNECTION).toBeCalledWith(MONGO_URI, expect.anything());
+    expect(MOCK_MONGOOSE_CREATE_CONNECTION).toBeCalledWith(
+      MONGO_ENV_VARS.MONGO_URI,
+      expect.anything(),
+    );
+  });
+
+  test('Connection should use MONGO_DB', async () => {
+    await createMongooseConnectionFromEnv();
+
+    expect(MOCK_MONGOOSE_CREATE_CONNECTION).toBeCalledWith(
+      expect.anything(),
+      expect.objectContaining({ dbName: MONGO_ENV_VARS.MONGO_DB }),
+    );
+  });
+
+  test('Connection should use MONGO_USER', async () => {
+    await createMongooseConnectionFromEnv();
+
+    expect(MOCK_MONGOOSE_CREATE_CONNECTION).toBeCalledWith(
+      expect.anything(),
+      expect.objectContaining({ user: MONGO_ENV_VARS.MONGO_USER }),
+    );
+  });
+
+  test('Connection should use MONGO_PASSWORD', async () => {
+    await createMongooseConnectionFromEnv();
+
+    expect(MOCK_MONGOOSE_CREATE_CONNECTION).toBeCalledWith(
+      expect.anything(),
+      expect.objectContaining({ pass: MONGO_ENV_VARS.MONGO_PASSWORD }),
+    );
   });
 
   test('Mongoose connection should be returned', async () => {

--- a/src/backingServices/mongo.ts
+++ b/src/backingServices/mongo.ts
@@ -1,7 +1,27 @@
 import { get as getEnvVar } from 'env-var';
-import { Connection, createConnection } from 'mongoose';
+import { Connection, ConnectionOptions, createConnection } from 'mongoose';
+
+export function getMongooseConnectionArgsFromEnv(): {
+  readonly uri: string;
+  readonly options: ConnectionOptions;
+} {
+  const mongoUri = getEnvVar('MONGO_URI').required().asString();
+  const mongoDb = getEnvVar('MONGO_DB').required().asString();
+  const mongoUser = getEnvVar('MONGO_USER').required().asString();
+  const mongoPassword = getEnvVar('MONGO_PASSWORD').required().asString();
+  return {
+    options: {
+      dbName: mongoDb,
+      pass: mongoPassword,
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      user: mongoUser,
+    },
+    uri: mongoUri,
+  };
+}
 
 export async function createMongooseConnectionFromEnv(): Promise<Connection> {
-  const mongoUri = getEnvVar('MONGO_URI').required().asString();
-  return createConnection(mongoUri, { useNewUrlParser: true, useUnifiedTopology: true });
+  const connectionArgs = getMongooseConnectionArgsFromEnv();
+  return createConnection(connectionArgs.uri, connectionArgs.options);
 }

--- a/src/functional_tests/pdc_client.test.ts
+++ b/src/functional_tests/pdc_client.test.ts
@@ -35,7 +35,13 @@ beforeAll(async () => {
 
 let natsStreamingConnection: Stan;
 beforeEach(async () => (natsStreamingConnection = await connectToNatsStreaming()));
-afterEach(async () => natsStreamingConnection.close());
+afterEach(async () => {
+  // Shut up Jest about leaving open handlers
+  await new Promise((resolve) => {
+    natsStreamingConnection.once('close', resolve);
+    natsStreamingConnection.close();
+  });
+});
 
 describe('PDC client', () => {
   test('Successfully delivered parcels should be taken off the queue', async () => {

--- a/src/services/fastifyUtils.ts
+++ b/src/services/fastifyUtils.ts
@@ -8,6 +8,8 @@ import {
   HTTPMethods,
 } from 'fastify';
 import { Logger } from 'pino';
+
+import { getMongooseConnectionArgsFromEnv } from '../backingServices/mongo';
 import { MAX_RAMF_MESSAGE_SIZE } from './constants';
 
 const DEFAULT_REQUEST_ID_HEADER = 'X-Request-Id';
@@ -67,8 +69,11 @@ export async function configureFastify<RouteOptions extends FastifyPluginOptions
 
   await Promise.all(routes.map((route) => server.register(route, routeOptions)));
 
-  const mongoUri = getEnvVar('MONGO_URI').required().asString();
-  await server.register(require('fastify-mongoose'), { uri: mongoUri });
+  const mongoConnectionArgs = getMongooseConnectionArgsFromEnv();
+  await server.register(require('fastify-mongoose'), {
+    ...mongoConnectionArgs.options,
+    uri: mongoConnectionArgs.uri,
+  });
 
   await server.ready();
 

--- a/src/services/pohttp/routes.spec.ts
+++ b/src/services/pohttp/routes.spec.ts
@@ -2,7 +2,7 @@ import { InvalidMessageError, Parcel } from '@relaycorp/relaynet-core';
 import { FastifyInstance } from 'fastify';
 import { InjectOptions } from 'light-my-request';
 
-import { mockSpy, PdaChain } from '../../_test_utils';
+import { mockSpy, MONGO_ENV_VARS, PdaChain } from '../../_test_utils';
 import * as natsStreaming from '../../backingServices/natsStreaming';
 import {
   configureMockEnvVars,
@@ -63,7 +63,7 @@ jest.spyOn(ParcelStore, 'initFromEnv').mockReturnValue(mockParcelStore);
 
 describe('receiveParcel', () => {
   configureMockEnvVars({
-    MONGO_URI: 'uri',
+    ...MONGO_ENV_VARS,
     NATS_CLUSTER_ID: STUB_NATS_CLUSTER_ID,
     NATS_SERVER_URL: STUB_NATS_SERVER_URL,
   });

--- a/src/services/poweb/_test_utils.ts
+++ b/src/services/poweb/_test_utils.ts
@@ -1,14 +1,10 @@
-// tslint:disable:no-let
-
 import { MockPrivateKeyStore, Parcel } from '@relaycorp/relaynet-core';
 import { Connection } from 'mongoose';
 
-import { arrayToAsyncIterable, mockSpy, PdaChain } from '../../_test_utils';
+import { arrayToAsyncIterable, mockSpy, MONGO_ENV_VARS, PdaChain } from '../../_test_utils';
 import * as privateKeyStore from '../../backingServices/privateKeyStore';
 import { configureMockEnvVars, generatePdaChain, mockFastifyMongoose } from '../_test_utils';
 import { ParcelStore } from '../parcelStore';
-
-const BASE_ENV_VARS = { MONGO_URI: 'mongodb://example.com' };
 
 export interface FixtureSet extends PdaChain {
   readonly mongooseConnection: Connection;
@@ -55,11 +51,11 @@ export function setUpCommonFixtures(): () => FixtureSet {
   });
   mockSpy(jest.spyOn(privateKeyStore, 'initVaultKeyStore'), () => mockPrivateKeyStore);
 
-  const mockEnvVars = configureMockEnvVars(BASE_ENV_VARS);
+  const mockEnvVars = configureMockEnvVars(MONGO_ENV_VARS);
   beforeEach(() => {
     const gatewayCertificate = certificatePath.publicGatewayCert;
     mockEnvVars({
-      ...BASE_ENV_VARS,
+      ...MONGO_ENV_VARS,
       GATEWAY_KEY_ID: gatewayCertificate.getSerialNumber().toString('base64'),
     });
   });


### PR DESCRIPTION
So that we can use the connection URI from Terraform in https://github.com/relaycorp/cloud-gateway/issues/5
