### PR TITLE
fix(chart): Drop TLS support at ingress level

### DIFF
--- a/chart/templates/global-ingress.yml
+++ b/chart/templates/global-ingress.yml
@@ -11,13 +11,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.enableTls }}
-  tls:
-    - hosts:
-      - {{ include "relaynet-internet-gateway.pohttpHost" . }}
-      - {{ include "relaynet-internet-gateway.powebHost" . }}
-      - {{ include "relaynet-internet-gateway.cogrpcHost" . }}
-  {{- end }}
   rules:
     - host: {{ include "relaynet-internet-gateway.pohttpHost" . }}
       http:


### PR DESCRIPTION
Instead, delegate it to the cloud provider. E.g.,: https://cloud.google.com/kubernetes-engine/docs/concepts/ingress

This is to fix the following internal issues:

- https://console.cloud.google.com/support/cases/detail/25545538?caseId=26633692&accountId=gcp-sa-0357795152&project=public-gw
- https://console.cloud.google.com/support/cases/detail/26633692?caseId=26633692&accountId=gcp-sa-0357795152&project=relaycorp-cloud-gateway

... Where the problem was that we were using `.spec.tls.hosts` without specifying a secret.