### PR TITLE
feat: Implement cloud logging and error reporting

### DIFF
--- a/chart/templates/global-cm.yml
+++ b/chart/templates/global-cm.yml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "relaynet-internet-gateway.labels" . | nindent 4 }}
 data:
+  GATEWAY_VERSION: {{ .Chart.Version }}
+
   NATS_SERVER_URL: {{ .Values.nats.serverUrl }}
   NATS_CLUSTER_ID: {{ .Values.nats.clusterId }}
 

--- a/chart/templates/global-cm.yml
+++ b/chart/templates/global-cm.yml
@@ -7,6 +7,7 @@ metadata:
 data:
   GATEWAY_VERSION: {{ .Chart.Version }}
 
+  LOG_LEVEL: {{ .Values.logging.level | quote }}
   {{- if .Values.logging.target }}
   LOG_TARGET: {{ .Values.logging.target }}
   {{- end }}

--- a/chart/templates/global-cm.yml
+++ b/chart/templates/global-cm.yml
@@ -7,6 +7,10 @@ metadata:
 data:
   GATEWAY_VERSION: {{ .Chart.Version }}
 
+  {{- if .Values.logging.target }}
+  LOG_TARGET: {{ .Values.logging.target }}
+  {{- end }}
+
   NATS_SERVER_URL: {{ .Values.nats.serverUrl }}
   NATS_CLUSTER_ID: {{ .Values.nats.clusterId }}
 

--- a/chart/templates/global-cm.yml
+++ b/chart/templates/global-cm.yml
@@ -10,6 +10,9 @@ data:
   {{- if .Values.logging.target }}
   LOG_TARGET: {{ .Values.logging.target }}
   {{- end }}
+  {{- if .Values.logging.envName }}
+  LOG_ENV_NAME: {{ .Values.logging.envName }}
+  {{- end }}
 
   NATS_SERVER_URL: {{ .Values.nats.serverUrl }}
   NATS_CLUSTER_ID: {{ .Values.nats.clusterId }}

--- a/chart/templates/pohttp-deploy.yml
+++ b/chart/templates/pohttp-deploy.yml
@@ -41,8 +41,6 @@ spec:
             - name: REQUEST_ID_HEADER
               value: {{ .Values.proxyRequestIdHeader | quote }}
             {{- end }}
-            - name: LOG_LEVEL
-              value: {{ .Values.logging.level | quote }}
           envFrom:
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}

--- a/chart/templates/pohttp-deploy.yml
+++ b/chart/templates/pohttp-deploy.yml
@@ -42,7 +42,7 @@ spec:
               value: {{ .Values.proxyRequestIdHeader | quote }}
             {{- end }}
             - name: LOG_LEVEL
-              value: {{ .Values.logLevel | quote }}
+              value: {{ .Values.logging.level | quote }}
           envFrom:
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}

--- a/chart/templates/poweb-deploy.yml
+++ b/chart/templates/poweb-deploy.yml
@@ -43,7 +43,7 @@ spec:
               value: {{ .Values.proxyRequestIdHeader | quote }}
             {{- end }}
             - name: LOG_LEVEL
-              value: {{ .Values.logLevel | quote }}
+              value: {{ .Values.logging.level | quote }}
           envFrom:
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}

--- a/chart/templates/poweb-deploy.yml
+++ b/chart/templates/poweb-deploy.yml
@@ -42,8 +42,6 @@ spec:
             - name: REQUEST_ID_HEADER
               value: {{ .Values.proxyRequestIdHeader | quote }}
             {{- end }}
-            - name: LOG_LEVEL
-              value: {{ .Values.logging.level | quote }}
           envFrom:
             - configMapRef:
                 name: {{ include "relaynet-internet-gateway.fullname" . }}

--- a/chart/values.dev.yml
+++ b/chart/values.dev.yml
@@ -8,7 +8,8 @@ fullnameOverride: public-gateway
 tags:
   dev: true
 
-logLevel: debug
+logging:
+  level: debug
 
 ingress:
   enableTls: false

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -17,6 +17,10 @@
         "level": {
           "type": "string",
           "enum": ["debug", "info", "warn", "error", "fatal"]
+        },
+        "target": {
+          "type": "string",
+          "enum": ["gcp"]
         }
       }
     },

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -21,6 +21,9 @@
         "target": {
           "type": "string",
           "enum": ["gcp"]
+        },
+        "envName": {
+          "type": "string"
         }
       }
     },

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "required": [
-    "logLevel",
+    "logging",
     "publicAddress",
     "pdcQueue",
     "mongo",
@@ -10,9 +10,15 @@
     "vault"
   ],
   "properties": {
-    "logLevel": {
-      "type": "string",
-      "enum": ["debug", "info", "warn", "error"]
+    "logging": {
+      "type": "object",
+      "required": ["level"],
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": ["debug", "info", "warn", "error", "fatal"]
+        }
+      }
     },
     "ingress": {
       "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,7 +5,8 @@
 tags:
   dev: false
 
-logLevel: info
+logging:
+  level: info
 
 image:
   repository: ghcr.io/relaycorp/relaynet-internet-gateway

--- a/docs/install.md
+++ b/docs/install.md
@@ -61,6 +61,7 @@ Check out [`relaycorp/cloud-gateway`](https://github.com/relaycorp/cloud-gateway
 | `ingress.annotations` | object | `{}` | Annotations for the ingress |
 | `ingress.enableTls` | boolean | `true` | Whether the ingress should use TLS. You still have to configure TLS through your cloud provider; see [GKE documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress), for example. |
 | `objectStore.backend` | string | | The type of object store used. Any value supported by [`@relaycorp/object-storage`](https://github.com/relaycorp/object-storage-js) (e.g., `s3`). |
+| `logging.level` | string | `info` | The [log level](./instrumentation.md). |
 
 ### Component-specific options
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -62,6 +62,7 @@ Check out [`relaycorp/cloud-gateway`](https://github.com/relaycorp/cloud-gateway
 | `ingress.enableTls` | boolean | `true` | Whether the ingress should use TLS. You still have to configure TLS through your cloud provider; see [GKE documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress), for example. |
 | `objectStore.backend` | string | | The type of object store used. Any value supported by [`@relaycorp/object-storage`](https://github.com/relaycorp/object-storage-js) (e.g., `s3`). |
 | `logging.level` | string | `info` | The [log level](./instrumentation.md). |
+| `logging.target` | string | | Any target supported by [@relaycorp/pino-cloud](https://www.npmjs.com/package/@relaycorp/pino-cloud); e.g., `gcp`. |
 
 ### Component-specific options
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -63,6 +63,7 @@ Check out [`relaycorp/cloud-gateway`](https://github.com/relaycorp/cloud-gateway
 | `objectStore.backend` | string | | The type of object store used. Any value supported by [`@relaycorp/object-storage`](https://github.com/relaycorp/object-storage-js) (e.g., `s3`). |
 | `logging.level` | string | `info` | The [log level](./instrumentation.md). |
 | `logging.target` | string | | Any target supported by [@relaycorp/pino-cloud](https://www.npmjs.com/package/@relaycorp/pino-cloud); e.g., `gcp`. |
+| `logging.envName` | string | `relaynet-internet-gateway` | A unique name for this instance of the gateway. Used by the `gcp` target as the _service name_ when pushing errors to Google Error Reporting, for example. |
 
 ### Component-specific options
 

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -4,7 +4,7 @@ permalink: /instrumentation
 ---
 # Instrumentation
 
-We use [pino](https://getpino.io/) to provide structured logs, which could in turn be consumed to provide [instrumentation](https://john-millikin.com/sre-school/instrumentation).
+We use [pino](https://getpino.io/) with [`@relaycorp/pino-cloud`](https://www.npmjs.com/package/@relaycorp/pino-cloud) to provide structured logs, which could in turn be consumed to provide [instrumentation](https://john-millikin.com/sre-school/instrumentation).
 
 ## Common logging attributes
 

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -22,4 +22,4 @@ We use log levels as follows:
 - `info`: Events for any outcome observed outside the gateway, or any unusual interaction with a backing service.
 - `warning`: Something has gone wrong but it's being handled gracefully. Triage can start on the next working day.
 - `error`: Something has gone wrong and triage must start within a few minutes. Wake up an SRE if necessary.
-- `critical`: Not used.
+- `fatal`: Not used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1993,11 +1993,10 @@
       }
     },
     "@relaycorp/pino-cloud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@relaycorp/pino-cloud/-/pino-cloud-1.0.0.tgz",
-      "integrity": "sha512-/3ielTghmn6lN8dUE62NyPABA5AHcY2F0UmATvuDgm7V0rSOIfS1cMwRqjK/6UuhiwUWbF8H9QvjN8/2fu/iJQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@relaycorp/pino-cloud/-/pino-cloud-1.0.2.tgz",
+      "integrity": "sha512-YlYSmdQ6lBJLaOZ7UQ9X5y4T2wM24VsAMjUaVnv4+yTYvrm630NiV/w0Gnuzc0Fwd2nwDgNu6NeFf//bdYRLeg==",
       "requires": {
-        "@types/pino": "^6.3.5",
         "pino": "^6.11.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1992,6 +1992,15 @@
         "aws-sdk": "^2.831.0"
       }
     },
+    "@relaycorp/pino-cloud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@relaycorp/pino-cloud/-/pino-cloud-1.0.0.tgz",
+      "integrity": "sha512-/3ielTghmn6lN8dUE62NyPABA5AHcY2F0UmATvuDgm7V0rSOIfS1cMwRqjK/6UuhiwUWbF8H9QvjN8/2fu/iJQ==",
+      "requires": {
+        "@types/pino": "^6.3.5",
+        "pino": "^6.11.0"
+      }
+    },
     "@relaycorp/relaynet-core": {
       "version": "1.42.3",
       "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-core/-/relaynet-core-1.42.3.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:ci:unit": "run-s build test:ci:unit:jest",
     "test:ci:unit:jest": "jest --config jest.config.ci.js --coverage",
     "cov": "run-s build test:unit && opn coverage/lcov-report/index.html",
-    "clean": "trash build test"
+    "clean": "trash build test coverage"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@relaycorp/cogrpc": "^1.3.1",
     "@relaycorp/keystore-vault": "^1.2.1",
     "@relaycorp/object-storage": "^1.3.2",
+    "@relaycorp/pino-cloud": "^1.0.0",
     "@relaycorp/relaynet-core": "^1.42.3",
     "@relaycorp/relaynet-pohttp": "^1.6.0",
     "@typegoose/typegoose": "^7.4.8",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@relaycorp/cogrpc": "^1.3.1",
     "@relaycorp/keystore-vault": "^1.2.1",
     "@relaycorp/object-storage": "^1.3.2",
-    "@relaycorp/pino-cloud": "^1.0.0",
+    "@relaycorp/pino-cloud": "^1.0.2",
     "@relaycorp/relaynet-core": "^1.42.3",
     "@relaycorp/relaynet-pohttp": "^1.6.0",
     "@typegoose/typegoose": "^7.4.8",

--- a/src/_test_utils.ts
+++ b/src/_test_utils.ts
@@ -72,20 +72,6 @@ export function mockSpy<T, Y extends any[]>(
   return spy;
 }
 
-/**
- * @deprecated Use `makeMockLogging()` instead.
- */
-export function mockPino(): pino.Logger {
-  const mockPinoLogger = {
-    debug: mockSpy(jest.fn()),
-    error: mockSpy(jest.fn()),
-    info: mockSpy(jest.fn()),
-    warn: mockSpy(jest.fn()),
-  };
-  jest.mock('pino', () => jest.fn().mockImplementation(() => mockPinoLogger));
-  return mockPinoLogger as any;
-}
-
 // tslint:disable-next-line:readonly-array
 export type MockLogSet = object[];
 

--- a/src/bin/pohttp-server.ts
+++ b/src/bin/pohttp-server.ts
@@ -1,7 +1,7 @@
 // tslint:disable-next-line:no-var-requires
 require('make-promises-safe');
 
-import { runFastify } from '../services/fastifyUtils';
 import { makeServer } from '../services/pohttp/server';
+import { runFastify } from '../utilities/fastify';
 
 makeServer().then(runFastify);

--- a/src/bin/poweb-server.ts
+++ b/src/bin/poweb-server.ts
@@ -1,7 +1,7 @@
 // tslint:disable-next-line:no-var-requires
 require('make-promises-safe');
 
-import { runFastify } from '../services/fastifyUtils';
 import { makeServer } from '../services/poweb/server';
+import { runFastify } from '../utilities/fastify';
 
 makeServer().then(runFastify);

--- a/src/services/_test_utils.ts
+++ b/src/services/_test_utils.ts
@@ -15,7 +15,7 @@ import { Connection } from 'mongoose';
 import * as stan from 'node-nats-streaming';
 
 import { PdaChain } from '../_test_utils';
-import { HTTP_METHODS } from './fastifyUtils';
+import { HTTP_METHODS } from '../utilities/fastify';
 
 export const TOMORROW = new Date();
 TOMORROW.setDate(TOMORROW.getDate() + 1);

--- a/src/services/cogrpc/server.spec.ts
+++ b/src/services/cogrpc/server.spec.ts
@@ -130,10 +130,10 @@ describe('runServer', () => {
     expect(mockServer.addService).toBeCalledWith(CargoRelayService, serviceImplementation);
   });
 
-  test('Pino should be configured with service name if custom logger is absent', async () => {
+  test('Logger should be configured if custom logger is absent', async () => {
     await runServer();
 
-    expect(mockMakeLogger).toBeCalledWith('cogrpc');
+    expect(mockMakeLogger).toBeCalledWith();
     const logger = getMockContext(mockMakeLogger).results[0].value;
     expect(makeServiceImplementationSpy).toBeCalledWith(
       expect.objectContaining({ baseLogger: logger }),

--- a/src/services/cogrpc/server.spec.ts
+++ b/src/services/cogrpc/server.spec.ts
@@ -5,7 +5,8 @@ import { Logger } from 'pino';
 import selfsigned from 'selfsigned';
 
 import { makeMockLogging, mockSpy, partialPinoLog } from '../../_test_utils';
-import { configureMockEnvVars } from '../_test_utils';
+import * as logging from '../../utilities/logging';
+import { configureMockEnvVars, getMockContext } from '../_test_utils';
 import { MAX_RAMF_MESSAGE_SIZE } from '../constants';
 import { runServer } from './server';
 import * as cogrpcService from './service';
@@ -41,6 +42,9 @@ const BASE_ENV_VARS = {
   SERVER_IP_ADDRESS: '127.0.0.1',
 };
 const mockEnvVars = configureMockEnvVars(BASE_ENV_VARS);
+
+const mockLogger = makeMockLogging().logger;
+const mockMakeLogger = mockSpy(jest.spyOn(logging, 'makeLogger'), () => mockLogger);
 
 describe('runServer', () => {
   test.each([
@@ -124,6 +128,16 @@ describe('runServer', () => {
     const serviceImplementation = makeServiceImplementationSpy.mock.results[0].value;
 
     expect(mockServer.addService).toBeCalledWith(CargoRelayService, serviceImplementation);
+  });
+
+  test('Pino should be configured with service name if custom logger is absent', async () => {
+    await runServer();
+
+    expect(mockMakeLogger).toBeCalledWith('cogrpc');
+    const logger = getMockContext(mockMakeLogger).results[0].value;
+    expect(makeServiceImplementationSpy).toBeCalledWith(
+      expect.objectContaining({ baseLogger: logger }),
+    );
   });
 
   test('Health check service should be added', async () => {

--- a/src/services/cogrpc/server.ts
+++ b/src/services/cogrpc/server.ts
@@ -2,9 +2,10 @@ import { CargoRelayService } from '@relaycorp/cogrpc';
 import { get as getEnvVar } from 'env-var';
 import { KeyCertPair, Server, ServerCredentials } from 'grpc';
 import grpcHealthCheck from 'grpc-health-check';
-import pino, { Logger } from 'pino';
+import { Logger } from 'pino';
 import * as selfsigned from 'selfsigned';
 
+import { makeLogger } from '../../utilities/logging';
 import { MAX_RAMF_MESSAGE_SIZE } from '../constants';
 import { makeServiceImplementation } from './service';
 
@@ -33,7 +34,7 @@ export async function runServer(logger?: Logger): Promise<void> {
     'grpc.max_receive_message_length': MAX_RECEIVED_MESSAGE_LENGTH,
   });
 
-  const baseLogger = logger ?? pino();
+  const baseLogger = logger ?? makeLogger('cogrpc');
   const serviceImplementation = await makeServiceImplementation({
     baseLogger,
     gatewayKeyIdBase64,

--- a/src/services/cogrpc/server.ts
+++ b/src/services/cogrpc/server.ts
@@ -34,7 +34,7 @@ export async function runServer(logger?: Logger): Promise<void> {
     'grpc.max_receive_message_length': MAX_RECEIVED_MESSAGE_LENGTH,
   });
 
-  const baseLogger = logger ?? makeLogger('cogrpc');
+  const baseLogger = logger ?? makeLogger();
   const serviceImplementation = await makeServiceImplementation({
     baseLogger,
     gatewayKeyIdBase64,

--- a/src/services/crcQueueWorker.spec.ts
+++ b/src/services/crcQueueWorker.spec.ts
@@ -140,7 +140,7 @@ describe('Queue subscription', () => {
   test('Logger should be configured', async () => {
     await processIncomingCrcCargo(STUB_WORKER_NAME);
 
-    expect(mockMakeLogger).toBeCalledWith('crcin');
+    expect(mockMakeLogger).toBeCalledWith();
   });
 
   test('Worker should subscribe to channel "crc-cargo"', async () => {

--- a/src/services/crcQueueWorker.spec.ts
+++ b/src/services/crcQueueWorker.spec.ts
@@ -18,11 +18,12 @@ import {
 import { Connection } from 'mongoose';
 import * as stan from 'node-nats-streaming';
 
-import { mockPino, mockSpy, PdaChain } from '../_test_utils';
+import { makeMockLogging, MockLogging, mockSpy, partialPinoLog, PdaChain } from '../_test_utils';
 import * as privateKeyStore from '../backingServices/keyStores';
 import * as mongo from '../backingServices/mongo';
 import { NatsStreamingClient } from '../backingServices/natsStreaming';
 import * as objectStorage from '../backingServices/objectStorage';
+import * as logging from '../utilities/logging';
 import {
   castMock,
   configureMockEnvVars,
@@ -30,11 +31,9 @@ import {
   getMockInstance,
   mockStanMessage,
 } from './_test_utils';
+import { processIncomingCrcCargo } from './crcQueueWorker';
 import * as mongoPublicKeyStore from './MongoPublicKeyStore';
 import { ParcelStore } from './parcelStore';
-
-const mockLogger = mockPino();
-import { processIncomingCrcCargo } from './crcQueueWorker';
 
 //region Stan-related fixtures
 
@@ -88,6 +87,7 @@ const mockStoreParcelFromPeerGateway = mockSpy(
 //endregion
 
 const BASE_ENV_VARS = {
+  GATEWAY_VERSION: '1',
   OBJECT_STORE_BUCKET,
 };
 configureMockEnvVars(BASE_ENV_VARS);
@@ -130,7 +130,19 @@ beforeAll(async () => {
   PARCEL_SERIALIZED = await PARCEL.serialize(CERT_CHAIN.pdaGranteePrivateKey);
 });
 
+let mockLogging: MockLogging;
+beforeAll(() => {
+  mockLogging = makeMockLogging();
+});
+const mockMakeLogger = mockSpy(jest.spyOn(logging, 'makeLogger'), () => mockLogging.logger);
+
 describe('Queue subscription', () => {
+  test('Logger should be configured', async () => {
+    await processIncomingCrcCargo(STUB_WORKER_NAME);
+
+    expect(mockMakeLogger).toBeCalledWith('crcin');
+  });
+
   test('Worker should subscribe to channel "crc-cargo"', async () => {
     await processIncomingCrcCargo(STUB_WORKER_NAME);
 
@@ -193,14 +205,13 @@ test('Cargo with invalid payload should be logged and ignored', async () => {
 
   await processIncomingCrcCargo(STUB_WORKER_NAME);
 
-  expect(mockLogger.info).toBeCalledWith(
-    {
+  expect(mockLogging.logs).toContainEqual(
+    partialPinoLog('info', 'Cargo payload is invalid', {
       cargoId: cargo.id,
       err: expect.objectContaining({ message: expect.stringMatching(/Could not deserialize/) }),
       peerGatewayAddress: await cargo.senderCertificate.calculateSubjectPrivateAddress(),
       worker: STUB_WORKER_NAME,
-    },
-    `Cargo payload is invalid`,
+    }),
   );
 
   expect(stanMessage.ack).toBeCalledTimes(1);
@@ -266,18 +277,17 @@ describe('Parcel processing', () => {
       await CERT_CHAIN.privateGatewayCert.calculateSubjectPrivateAddress(),
       MOCK_MONGOOSE_CONNECTION,
       mockNatsClient,
-      mockLogger,
+      mockLogging.logger,
     );
-    expect(mockLogger.debug).toBeCalledWith(
-      {
+    expect(mockLogging.logs).toContainEqual(
+      partialPinoLog('debug', 'Parcel was stored', {
         cargoId: cargo.id,
         parcelId: PARCEL.id,
         parcelObjectKey: `parcels/${PARCEL.id}`,
         parcelSenderAddress: await PARCEL.senderCertificate.calculateSubjectPrivateAddress(),
         peerGatewayAddress: await CERT_CHAIN.privateGatewayCert.calculateSubjectPrivateAddress(),
         worker: STUB_WORKER_NAME,
-      },
-      'Parcel was stored',
+      }),
     );
   });
 
@@ -291,16 +301,15 @@ describe('Parcel processing', () => {
 
     await processIncomingCrcCargo(STUB_WORKER_NAME);
 
-    expect(mockLogger.debug).toBeCalledWith(
-      {
+    expect(mockLogging.logs).toContainEqual(
+      partialPinoLog('debug', 'Ignoring previously processed parcel', {
         cargoId: cargo.id,
         parcelId: PARCEL.id,
         parcelObjectKey: null,
         parcelSenderAddress: await PARCEL.senderCertificate.calculateSubjectPrivateAddress(),
         peerGatewayAddress: await CERT_CHAIN.privateGatewayCert.calculateSubjectPrivateAddress(),
         worker: STUB_WORKER_NAME,
-      },
-      'Ignoring previously processed parcel',
+      }),
     );
   });
 
@@ -313,14 +322,13 @@ describe('Parcel processing', () => {
 
     await processIncomingCrcCargo(STUB_WORKER_NAME);
 
-    expect(mockLogger.info).toBeCalledWith(
-      {
+    expect(mockLogging.logs).toContainEqual(
+      partialPinoLog('info', 'Parcel is invalid', {
         cargoId: cargo.id,
-        err: expect.any(InvalidMessageError),
+        err: expect.objectContaining({ type: InvalidMessageError.name }),
         peerGatewayAddress: await CERT_CHAIN.privateGatewayCert.calculateSubjectPrivateAddress(),
         worker: STUB_WORKER_NAME,
-      },
-      'Parcel is invalid',
+      }),
     );
   });
 
@@ -394,14 +402,13 @@ test('Cargo containing invalid messages should be logged and ignored', async () 
   await processIncomingCrcCargo(STUB_WORKER_NAME);
 
   const cargoSenderAddress = await CERT_CHAIN.privateGatewayCert.calculateSubjectPrivateAddress();
-  expect(mockLogger.info).toBeCalledWith(
-    {
+  expect(mockLogging.logs).toContainEqual(
+    partialPinoLog('info', 'Cargo contains an invalid message', {
       cargoId: (await Cargo.deserialize(stubCargo1Serialized)).id,
-      error: expect.any(InvalidMessageError),
+      err: expect.objectContaining({ type: InvalidMessageError.name }),
       peerGatewayAddress: cargoSenderAddress,
       worker: STUB_WORKER_NAME,
-    },
-    `Cargo contains an invalid message`,
+    }),
   );
 });
 

--- a/src/services/crcQueueWorker.ts
+++ b/src/services/crcQueueWorker.ts
@@ -23,7 +23,7 @@ import { MongoPublicKeyStore } from './MongoPublicKeyStore';
 import { ParcelStore } from './parcelStore';
 
 export async function processIncomingCrcCargo(workerName: string): Promise<void> {
-  const logger = makeLogger('crcin');
+  const logger = makeLogger();
 
   const natsStreamingClient = NatsStreamingClient.initFromEnv(workerName);
 

--- a/src/services/fastifyUtils.ts
+++ b/src/services/fastifyUtils.ts
@@ -10,13 +10,14 @@ import {
 import { Logger } from 'pino';
 
 import { getMongooseConnectionArgsFromEnv } from '../backingServices/mongo';
+import { makeLogger } from '../utilities/logging';
 import { MAX_RAMF_MESSAGE_SIZE } from './constants';
 
 const DEFAULT_REQUEST_ID_HEADER = 'X-Request-Id';
 const SERVER_PORT = 8080;
 const SERVER_HOST = '0.0.0.0';
 
-export type FastifyLogger = boolean | FastifyLoggerOptions | Logger;
+export type FastifyLogger = FastifyLoggerOptions | Logger;
 
 export const HTTP_METHODS: readonly HTTPMethods[] = [
   'POST',
@@ -53,13 +54,14 @@ export function registerDisallowedMethods(
  * This function doesn't call .listen() so we can use .inject() for testing purposes.
  */
 export async function configureFastify<RouteOptions extends FastifyPluginOptions = {}>(
+  serviceName: string,
   routes: ReadonlyArray<FastifyPluginCallback<RouteOptions>>,
   routeOptions?: RouteOptions,
-  logger: FastifyLogger = true,
+  logger?: FastifyLogger,
 ): Promise<FastifyInstance> {
   const server = fastify({
     bodyLimit: MAX_RAMF_MESSAGE_SIZE,
-    logger: getFinalLogger(logger),
+    logger: logger ?? makeLogger(serviceName),
     requestIdHeader: getEnvVar('REQUEST_ID_HEADER')
       .default(DEFAULT_REQUEST_ID_HEADER)
       .asString()
@@ -78,14 +80,6 @@ export async function configureFastify<RouteOptions extends FastifyPluginOptions
   await server.ready();
 
   return server;
-}
-
-function getFinalLogger(logger: FastifyLogger): FastifyLogger {
-  if (logger !== true) {
-    return logger;
-  }
-  const logLevelEnvVar = getEnvVar('LOG_LEVEL').asString()?.toLowerCase();
-  return logLevelEnvVar ? { level: logLevelEnvVar } : logger;
 }
 
 export async function runFastify(fastifyInstance: FastifyInstance): Promise<void> {

--- a/src/services/internetBoundParcelsQueueWorker.spec.ts
+++ b/src/services/internetBoundParcelsQueueWorker.spec.ts
@@ -74,7 +74,7 @@ describe('processInternetBoundParcels', () => {
 
     await processInternetBoundParcels(WORKER_NAME, OWN_POHTTP_ADDRESS);
 
-    expect(mockMakeLogger).toBeCalledWith('pdcout');
+    expect(mockMakeLogger).toBeCalledWith();
   });
 
   test('Expired parcels should be skipped and deleted from store', async () => {

--- a/src/services/internetBoundParcelsQueueWorker.ts
+++ b/src/services/internetBoundParcelsQueueWorker.ts
@@ -19,7 +19,7 @@ export async function processInternetBoundParcels(
   workerName: string,
   ownPohttpAddress: string,
 ): Promise<void> {
-  const logger = makeLogger('pdcout');
+  const logger = makeLogger();
 
   const parcelStoreBucket = getEnvVar('OBJECT_STORE_BUCKET').required().asString();
   const parcelStore = new ParcelStore(initObjectStoreFromEnv(), parcelStoreBucket);

--- a/src/services/pohttp/routes.spec.ts
+++ b/src/services/pohttp/routes.spec.ts
@@ -64,6 +64,7 @@ jest.spyOn(ParcelStore, 'initFromEnv').mockReturnValue(mockParcelStore);
 describe('receiveParcel', () => {
   configureMockEnvVars({
     ...MONGO_ENV_VARS,
+    GATEWAY_VERSION: '1.0.2',
     NATS_CLUSTER_ID: STUB_NATS_CLUSTER_ID,
     NATS_SERVER_URL: STUB_NATS_SERVER_URL,
   });

--- a/src/services/pohttp/routes.ts
+++ b/src/services/pohttp/routes.ts
@@ -4,7 +4,7 @@ import { get as getEnvVar } from 'env-var';
 import { FastifyInstance, FastifyReply } from 'fastify';
 
 import { NatsStreamingClient } from '../../backingServices/natsStreaming';
-import { registerDisallowedMethods } from '../fastifyUtils';
+import { registerDisallowedMethods } from '../../utilities/fastify';
 import { ParcelStore } from '../parcelStore';
 
 export default async function registerRoutes(

--- a/src/services/pohttp/server.spec.ts
+++ b/src/services/pohttp/server.spec.ts
@@ -9,16 +9,10 @@ const mockConfigureFastify = mockSpy(
 );
 
 describe('makeServer', () => {
-  test('Service name should be passed to fastify configuration', async () => {
-    await makeServer();
-
-    expect(mockConfigureFastify).toBeCalledWith('pohttp', expect.anything());
-  });
-
   test('Routes should be loaded', async () => {
     await makeServer();
 
-    expect(mockConfigureFastify).toBeCalledWith(expect.anything(), [require('./routes').default]);
+    expect(mockConfigureFastify).toBeCalledWith([require('./routes').default]);
   });
 
   test('Fastify instance should be returned', async () => {

--- a/src/services/pohttp/server.spec.ts
+++ b/src/services/pohttp/server.spec.ts
@@ -9,11 +9,16 @@ const mockConfigureFastify = mockSpy(
 );
 
 describe('makeServer', () => {
+  test('Service name should be passed to fastify configuration', async () => {
+    await makeServer();
+
+    expect(mockConfigureFastify).toBeCalledWith('pohttp', expect.anything());
+  });
+
   test('Routes should be loaded', async () => {
     await makeServer();
 
-    expect(mockConfigureFastify).toBeCalledTimes(1);
-    expect(mockConfigureFastify).toBeCalledWith([require('./routes').default]);
+    expect(mockConfigureFastify).toBeCalledWith(expect.anything(), [require('./routes').default]);
   });
 
   test('Fastify instance should be returned', async () => {

--- a/src/services/pohttp/server.spec.ts
+++ b/src/services/pohttp/server.spec.ts
@@ -1,5 +1,5 @@
 import { mockSpy } from '../../_test_utils';
-import * as fastifyUtils from '../fastifyUtils';
+import * as fastifyUtils from '../../utilities/fastify';
 import { makeServer } from './server';
 
 const mockFastifyInstance = {};

--- a/src/services/pohttp/server.ts
+++ b/src/services/pohttp/server.ts
@@ -9,5 +9,5 @@ import routes from './routes';
  * This function doesn't call .listen() so we can use .inject() for testing purposes.
  */
 export async function makeServer(): Promise<FastifyInstance> {
-  return configureFastify([routes]);
+  return configureFastify('pohttp', [routes]);
 }

--- a/src/services/pohttp/server.ts
+++ b/src/services/pohttp/server.ts
@@ -9,5 +9,5 @@ import routes from './routes';
  * This function doesn't call .listen() so we can use .inject() for testing purposes.
  */
 export async function makeServer(): Promise<FastifyInstance> {
-  return configureFastify('pohttp', [routes]);
+  return configureFastify([routes]);
 }

--- a/src/services/pohttp/server.ts
+++ b/src/services/pohttp/server.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 
-import { configureFastify } from '../fastifyUtils';
+import { configureFastify } from '../../utilities/fastify';
 import routes from './routes';
 
 /**

--- a/src/services/poweb/_test_utils.ts
+++ b/src/services/poweb/_test_utils.ts
@@ -57,6 +57,7 @@ export function setUpCommonFixtures(): () => FixtureSet {
     mockEnvVars({
       ...MONGO_ENV_VARS,
       GATEWAY_KEY_ID: gatewayCertificate.getSerialNumber().toString('base64'),
+      GATEWAY_VERSION: '1.0.2',
     });
   });
 

--- a/src/services/poweb/healthcheck.ts
+++ b/src/services/poweb/healthcheck.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 
-import { registerDisallowedMethods } from '../fastifyUtils';
+import { registerDisallowedMethods } from '../../utilities/fastify';
 
 export default async function registerRoutes(
   fastify: FastifyInstance,

--- a/src/services/poweb/parcelDelivery.ts
+++ b/src/services/poweb/parcelDelivery.ts
@@ -9,8 +9,8 @@ import { FastifyInstance, FastifyLoggerInstance, FastifyReply } from 'fastify';
 import { Connection } from 'mongoose';
 
 import { NatsStreamingClient } from '../../backingServices/natsStreaming';
+import { registerDisallowedMethods } from '../../utilities/fastify';
 import { retrieveOwnCertificates } from '../certs';
-import { registerDisallowedMethods } from '../fastifyUtils';
 import { ParcelStore } from '../parcelStore';
 import { CONTENT_TYPES } from './contentTypes';
 import RouteOptions from './RouteOptions';

--- a/src/services/poweb/preRegistration.ts
+++ b/src/services/poweb/preRegistration.ts
@@ -2,7 +2,7 @@ import { PrivateNodeRegistrationAuthorization } from '@relaycorp/relaynet-core';
 import bufferToArray from 'buffer-to-arraybuffer';
 import { FastifyInstance, FastifyReply } from 'fastify';
 
-import { registerDisallowedMethods } from '../fastifyUtils';
+import { registerDisallowedMethods } from '../../utilities/fastify';
 import { CONTENT_TYPES } from './contentTypes';
 import RouteOptions from './RouteOptions';
 

--- a/src/services/poweb/registration.ts
+++ b/src/services/poweb/registration.ts
@@ -9,8 +9,8 @@ import {
 import bufferToArray from 'buffer-to-arraybuffer';
 import { FastifyInstance, FastifyReply } from 'fastify';
 
+import { registerDisallowedMethods } from '../../utilities/fastify';
 import { sha256 } from '../../utils';
-import { registerDisallowedMethods } from '../fastifyUtils';
 import { CONTENT_TYPES } from './contentTypes';
 import RouteOptions from './RouteOptions';
 

--- a/src/services/poweb/server.spec.ts
+++ b/src/services/poweb/server.spec.ts
@@ -1,5 +1,5 @@
 import { mockSpy } from '../../_test_utils';
-import * as fastifyUtils from '../fastifyUtils';
+import * as fastifyUtils from '../../utilities/fastify';
 import { setUpCommonFixtures } from './_test_utils';
 import RouteOptions from './RouteOptions';
 import { makeServer } from './server';

--- a/src/services/poweb/server.spec.ts
+++ b/src/services/poweb/server.spec.ts
@@ -13,21 +13,10 @@ const mockConfigureFastify = mockSpy(
 );
 
 describe('makeServer', () => {
-  test('Service name should be passed to fastify configuration', async () => {
-    await makeServer();
-
-    expect(mockConfigureFastify).toBeCalledWith(
-      'poweb',
-      expect.anything(),
-      expect.anything(),
-      undefined,
-    );
-  });
-
   test('Function to retrieve the key pair should be added to the options', async () => {
     await makeServer();
 
-    const routeOptions = mockConfigureFastify.mock.calls[0][2] as RouteOptions;
+    const routeOptions = mockConfigureFastify.mock.calls[0][1] as RouteOptions;
     const retriever = routeOptions.keyPairRetriever;
     const retrieverCertificate = (await retriever()).certificate;
     expect(retrieverCertificate.isEqual(getFixtures().publicGatewayCert)).toBeTrue();
@@ -36,12 +25,7 @@ describe('makeServer', () => {
   test('No logger should be passed by default', async () => {
     await makeServer();
 
-    expect(mockConfigureFastify).toBeCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      undefined,
-    );
+    expect(mockConfigureFastify).toBeCalledWith(expect.anything(), expect.anything(), undefined);
   });
 
   test('Any explicit logger should be honored', async () => {
@@ -49,12 +33,7 @@ describe('makeServer', () => {
 
     await makeServer(logger);
 
-    expect(mockConfigureFastify).toBeCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      logger,
-    );
+    expect(mockConfigureFastify).toBeCalledWith(expect.anything(), expect.anything(), logger);
   });
 
   test('Fastify instance should be returned', async () => {

--- a/src/services/poweb/server.spec.ts
+++ b/src/services/poweb/server.spec.ts
@@ -1,5 +1,3 @@
-// tslint:disable:no-let
-
 import { mockSpy } from '../../_test_utils';
 import * as fastifyUtils from '../fastifyUtils';
 import { setUpCommonFixtures } from './_test_utils';
@@ -15,10 +13,21 @@ const mockConfigureFastify = mockSpy(
 );
 
 describe('makeServer', () => {
+  test('Service name should be passed to fastify configuration', async () => {
+    await makeServer();
+
+    expect(mockConfigureFastify).toBeCalledWith(
+      'poweb',
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
+  });
+
   test('Function to retrieve the key pair should be added to the options', async () => {
     await makeServer();
 
-    const routeOptions = mockConfigureFastify.mock.calls[0][1] as RouteOptions;
+    const routeOptions = mockConfigureFastify.mock.calls[0][2] as RouteOptions;
     const retriever = routeOptions.keyPairRetriever;
     const retrieverCertificate = (await retriever()).certificate;
     expect(retrieverCertificate.isEqual(getFixtures().publicGatewayCert)).toBeTrue();
@@ -27,7 +36,12 @@ describe('makeServer', () => {
   test('No logger should be passed by default', async () => {
     await makeServer();
 
-    expect(mockConfigureFastify).toBeCalledWith(expect.anything(), expect.anything(), undefined);
+    expect(mockConfigureFastify).toBeCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
   });
 
   test('Any explicit logger should be honored', async () => {
@@ -35,7 +49,12 @@ describe('makeServer', () => {
 
     await makeServer(logger);
 
-    expect(mockConfigureFastify).toBeCalledWith(expect.anything(), expect.anything(), logger);
+    expect(mockConfigureFastify).toBeCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      logger,
+    );
   });
 
   test('Fastify instance should be returned', async () => {

--- a/src/services/poweb/server.ts
+++ b/src/services/poweb/server.ts
@@ -26,6 +26,7 @@ const ROUTES: ReadonlyArray<FastifyPluginCallback<RouteOptions>> = [
  */
 export async function makeServer(logger?: FastifyLogger): Promise<FastifyInstance> {
   return configureFastify(
+    'poweb',
     ROUTES,
     {
       keyPairRetriever: makeKeyPairRetriever(),

--- a/src/services/poweb/server.ts
+++ b/src/services/poweb/server.ts
@@ -26,7 +26,6 @@ const ROUTES: ReadonlyArray<FastifyPluginCallback<RouteOptions>> = [
  */
 export async function makeServer(logger?: FastifyLogger): Promise<FastifyInstance> {
   return configureFastify(
-    'poweb',
     ROUTES,
     {
       keyPairRetriever: makeKeyPairRetriever(),

--- a/src/services/poweb/server.ts
+++ b/src/services/poweb/server.ts
@@ -3,7 +3,7 @@ import { get as getEnvVar } from 'env-var';
 import { FastifyInstance, FastifyPluginCallback } from 'fastify';
 
 import { initVaultKeyStore } from '../../backingServices/keyStores';
-import { configureFastify, FastifyLogger } from '../fastifyUtils';
+import { configureFastify, FastifyLogger } from '../../utilities/fastify';
 import healthcheck from './healthcheck';
 import parcelCollection from './parcelCollection';
 import parcelDelivery from './parcelDelivery';

--- a/src/utilities/fastify.spec.ts
+++ b/src/utilities/fastify.spec.ts
@@ -3,10 +3,10 @@ import { fastify, FastifyInstance, FastifyPluginCallback } from 'fastify';
 import pino from 'pino';
 
 import { mockSpy, MONGO_ENV_VARS } from '../_test_utils';
-import * as logging from '../utilities/logging';
-import { configureMockEnvVars, getMockContext, getMockInstance } from './_test_utils';
-import { MAX_RAMF_MESSAGE_SIZE } from './constants';
-import { configureFastify, runFastify } from './fastifyUtils';
+import { configureMockEnvVars, getMockContext, getMockInstance } from '../services/_test_utils';
+import { MAX_RAMF_MESSAGE_SIZE } from '../services/constants';
+import { configureFastify, runFastify } from './fastify';
+import * as logging from './logging';
 
 const mockFastify: FastifyInstance = {
   listen: mockSpy(jest.fn()),

--- a/src/utilities/fastify.spec.ts
+++ b/src/utilities/fastify.spec.ts
@@ -28,19 +28,17 @@ const mockMakeLogger = mockSpy(jest.spyOn(logging, 'makeLogger'));
 const dummyRoutes: FastifyPluginCallback = () => null;
 
 describe('configureFastify', () => {
-  const SERVICE_NAME = 'the-service';
-
   test('Logger should be enabled by default', () => {
-    configureFastify(SERVICE_NAME, [dummyRoutes]);
+    configureFastify([dummyRoutes]);
 
-    expect(mockMakeLogger).toBeCalledWith(SERVICE_NAME);
+    expect(mockMakeLogger).toBeCalledWith();
     const logger = getMockContext(mockMakeLogger).results[0].value;
     expect(fastify).toBeCalledWith(expect.objectContaining({ logger }));
   });
 
   test('Custom logger should be honoured', () => {
     const customLogger = pino();
-    configureFastify(SERVICE_NAME, [dummyRoutes], undefined, customLogger);
+    configureFastify([dummyRoutes], undefined, customLogger);
 
     expect(fastify).toBeCalledWith(
       expect.objectContaining({
@@ -50,7 +48,7 @@ describe('configureFastify', () => {
   });
 
   test('X-Request-Id should be the default request id header', () => {
-    configureFastify(SERVICE_NAME, [dummyRoutes]);
+    configureFastify([dummyRoutes]);
 
     const fastifyCallArgs = getMockContext(fastify).calls[0];
     expect(fastifyCallArgs[0]).toHaveProperty('requestIdHeader', 'x-request-id');
@@ -60,28 +58,28 @@ describe('configureFastify', () => {
     const requestIdHeader = 'X-Id';
     mockEnvVars({ ...MONGO_ENV_VARS, REQUEST_ID_HEADER: requestIdHeader });
 
-    configureFastify(SERVICE_NAME, [dummyRoutes]);
+    configureFastify([dummyRoutes]);
 
     const fastifyCallArgs = getMockContext(fastify).calls[0];
     expect(fastifyCallArgs[0]).toHaveProperty('requestIdHeader', requestIdHeader.toLowerCase());
   });
 
   test('Maximum request body should allow for the largest RAMF message', () => {
-    configureFastify(SERVICE_NAME, [dummyRoutes]);
+    configureFastify([dummyRoutes]);
 
     const fastifyCallArgs = getMockContext(fastify).calls[0];
     expect(fastifyCallArgs[0]).toHaveProperty('bodyLimit', MAX_RAMF_MESSAGE_SIZE);
   });
 
   test('Proxy request headers should be trusted', () => {
-    configureFastify(SERVICE_NAME, [dummyRoutes]);
+    configureFastify([dummyRoutes]);
 
     const fastifyCallArgs = getMockContext(fastify).calls[0];
     expect(fastifyCallArgs[0]).toHaveProperty('trustProxy', true);
   });
 
   test('Routes should be loaded', async () => {
-    await configureFastify(SERVICE_NAME, [dummyRoutes]);
+    await configureFastify([dummyRoutes]);
 
     expect(mockFastify.register).toBeCalledWith(dummyRoutes, undefined);
   });
@@ -94,13 +92,13 @@ describe('configureFastify', () => {
       }
     });
 
-    await expect(configureFastify(SERVICE_NAME, [dummyRoutes])).rejects.toEqual(error);
+    await expect(configureFastify([dummyRoutes])).rejects.toEqual(error);
   });
 
   test('Any route options should be passed when registering the route', async () => {
     const options = { foo: 'oof' };
 
-    await configureFastify(SERVICE_NAME, [dummyRoutes], options);
+    await configureFastify([dummyRoutes], options);
 
     expect(mockFastify.register).toBeCalledWith(dummyRoutes, options);
   });
@@ -108,11 +106,11 @@ describe('configureFastify', () => {
   test('MongoDB connection arguments should be set', async () => {
     mockEnvVars({ MONGO_URI: undefined });
 
-    await expect(configureFastify(SERVICE_NAME, [dummyRoutes])).rejects.toBeInstanceOf(EnvVarError);
+    await expect(configureFastify([dummyRoutes])).rejects.toBeInstanceOf(EnvVarError);
   });
 
   test('The fastify-mongoose plugin should be configured', async () => {
-    await configureFastify(SERVICE_NAME, [dummyRoutes]);
+    await configureFastify([dummyRoutes]);
 
     expect(mockFastify.register).toBeCalledWith(
       require('fastify-mongoose'),
@@ -125,13 +123,13 @@ describe('configureFastify', () => {
   });
 
   test('It should wait for the Fastify server to be ready', async () => {
-    await configureFastify(SERVICE_NAME, [dummyRoutes]);
+    await configureFastify([dummyRoutes]);
 
     expect(mockFastify.ready).toBeCalledTimes(1);
   });
 
   test('Server instance should be returned', async () => {
-    const serverInstance = await configureFastify(SERVICE_NAME, [dummyRoutes]);
+    const serverInstance = await configureFastify([dummyRoutes]);
 
     expect(serverInstance).toBe(mockFastify);
   });

--- a/src/utilities/fastify.ts
+++ b/src/utilities/fastify.ts
@@ -54,14 +54,13 @@ export function registerDisallowedMethods(
  * This function doesn't call .listen() so we can use .inject() for testing purposes.
  */
 export async function configureFastify<RouteOptions extends FastifyPluginOptions = {}>(
-  serviceName: string,
   routes: ReadonlyArray<FastifyPluginCallback<RouteOptions>>,
   routeOptions?: RouteOptions,
   logger?: FastifyLogger,
 ): Promise<FastifyInstance> {
   const server = fastify({
     bodyLimit: MAX_RAMF_MESSAGE_SIZE,
-    logger: logger ?? makeLogger(serviceName),
+    logger: logger ?? makeLogger(),
     requestIdHeader: getEnvVar('REQUEST_ID_HEADER')
       .default(DEFAULT_REQUEST_ID_HEADER)
       .asString()

--- a/src/utilities/fastify.ts
+++ b/src/utilities/fastify.ts
@@ -10,8 +10,8 @@ import {
 import { Logger } from 'pino';
 
 import { getMongooseConnectionArgsFromEnv } from '../backingServices/mongo';
-import { makeLogger } from '../utilities/logging';
-import { MAX_RAMF_MESSAGE_SIZE } from './constants';
+import { MAX_RAMF_MESSAGE_SIZE } from '../services/constants';
+import { makeLogger } from './logging';
 
 const DEFAULT_REQUEST_ID_HEADER = 'X-Request-Id';
 const SERVER_PORT = 8080;

--- a/src/utilities/logging.spec.ts
+++ b/src/utilities/logging.spec.ts
@@ -1,0 +1,78 @@
+import { getPinoOptions } from '@relaycorp/pino-cloud';
+import { EnvVarError } from 'env-var';
+import pino from 'pino';
+
+import { configureMockEnvVars, getMockInstance } from '../services/_test_utils';
+import { makeLogger } from './logging';
+
+const REQUIRED_ENV_VARS = {
+  GATEWAY_VERSION: '1.0.1',
+};
+const mockEnvVars = configureMockEnvVars(REQUIRED_ENV_VARS);
+
+const COMPONENT = 'the-component';
+
+jest.mock('@relaycorp/pino-cloud', () => ({
+  getPinoOptions: jest.fn().mockReturnValue({}),
+}));
+
+describe('makeLogger', () => {
+  test('Log level should be info if LOG_LEVEL env var is absent', () => {
+    mockEnvVars(REQUIRED_ENV_VARS);
+
+    const logger = makeLogger(COMPONENT);
+
+    expect(logger).toHaveProperty('level', 'info');
+  });
+
+  test('Log level in LOG_LEVEL env var should be honoured if present', () => {
+    const loglevel = 'debug';
+    mockEnvVars({ ...REQUIRED_ENV_VARS, LOG_LEVEL: loglevel });
+
+    const logger = makeLogger(COMPONENT);
+
+    expect(logger).toHaveProperty('level', loglevel);
+  });
+
+  test('Log level in LOG_LEVEL env var should be lower-cased if present', () => {
+    const loglevel = 'DEBUG';
+    mockEnvVars({ ...REQUIRED_ENV_VARS, LOG_LEVEL: loglevel });
+
+    const logger = makeLogger(COMPONENT);
+
+    expect(logger).toHaveProperty('level', loglevel.toLowerCase());
+  });
+
+  test('GATEWAY_VERSION env var should be required', () => {
+    mockEnvVars({ ...REQUIRED_ENV_VARS, GATEWAY_VERSION: undefined });
+
+    expect(() => makeLogger(COMPONENT)).toThrowWithMessage(EnvVarError, /GATEWAY_VERSION/);
+  });
+
+  test('Cloud logging options should be used', () => {
+    const messageKey = 'foo';
+    getMockInstance(getPinoOptions).mockReturnValue({ messageKey });
+    const logger = makeLogger(COMPONENT);
+
+    expect(logger[pino.symbols.messageKeySym as any]).toEqual(messageKey);
+    expect(getPinoOptions).toBeCalledWith(undefined, {
+      name: COMPONENT,
+      version: REQUIRED_ENV_VARS.GATEWAY_VERSION,
+    });
+  });
+
+  test('LOG_TARGET env var should be honoured if present', () => {
+    const loggingTarget = 'the-logging-target';
+    mockEnvVars({ ...REQUIRED_ENV_VARS, LOG_TARGET: loggingTarget });
+
+    makeLogger(COMPONENT);
+
+    expect(getPinoOptions).toBeCalledWith(loggingTarget, expect.anything());
+  });
+
+  test('Logging target should be unset if LOG_TARGET env var is absent', () => {
+    makeLogger(COMPONENT);
+
+    expect(getPinoOptions).toBeCalledWith(undefined, expect.anything());
+  });
+});

--- a/src/utilities/logging.ts
+++ b/src/utilities/logging.ts
@@ -2,10 +2,13 @@ import { getPinoOptions, LoggingTarget } from '@relaycorp/pino-cloud';
 import { get as getEnvVar } from 'env-var';
 import pino, { Level, Logger } from 'pino';
 
-export function makeLogger(component: string): Logger {
+const DEFAULT_APP_NAME = 'relaynet-internet-gateway';
+
+export function makeLogger(): Logger {
   const logTarget = getEnvVar('LOG_TARGET').asString();
   const gatewayVersion = getEnvVar('GATEWAY_VERSION').required().asString();
-  const appContext = { name: component, version: gatewayVersion };
+  const logEnvName = getEnvVar('LOG_ENV_NAME').default(DEFAULT_APP_NAME).asString();
+  const appContext = { name: logEnvName, version: gatewayVersion };
   const cloudPinoOptions = getPinoOptions(logTarget as LoggingTarget, appContext);
 
   const logLevel = getEnvVar('LOG_LEVEL').default('info').asString().toLowerCase() as Level;

--- a/src/utilities/logging.ts
+++ b/src/utilities/logging.ts
@@ -1,0 +1,13 @@
+import { getPinoOptions, LoggingTarget } from '@relaycorp/pino-cloud';
+import { get as getEnvVar } from 'env-var';
+import pino, { Level, Logger } from 'pino';
+
+export function makeLogger(component: string): Logger {
+  const logTarget = getEnvVar('LOG_TARGET').asString();
+  const gatewayVersion = getEnvVar('GATEWAY_VERSION').required().asString();
+  const appContext = { name: component, version: gatewayVersion };
+  const cloudPinoOptions = getPinoOptions(logTarget as LoggingTarget, appContext);
+
+  const logLevel = getEnvVar('LOG_LEVEL').default('info').asString().toLowerCase() as Level;
+  return pino({ ...cloudPinoOptions, level: logLevel });
+}


### PR DESCRIPTION
Part of https://github.com/relaycorp/cloud-gateway/issues/10

TODO

- [x] Integrate queues
- [x] Capture `logging.target`
- [x] Capture `logging.appPrefix`.

BREAKING CHANGES:

- Helm value `logLevel` is now `logging.level`.

UPGRADE NOTES:

- Set `logging.envName` and `logging.target`.