### PR TITLE
fix: Ensure fatal logs are issued reliably when processes crash

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,7 +69,7 @@ jobs:
       - run: npm run test:functional
         env:
           IS_GITHUB: 'true'
-        timeout-minutes: 1
+        timeout-minutes: 2
       - name: Output diagnostic information upon failure
         if: failure()
         run: .github/scripts/output-diagnostics.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ FROM node:12.20.1-slim
 WORKDIR /opt/gw
 COPY --from=build /tmp/gw ./
 USER node
-ENTRYPOINT ["node"]
+ENTRYPOINT ["node", "--unhandled-rejections=strict"]
 EXPOSE 8080

--- a/chart/templates/cogrpc-deploy.yml
+++ b/chart/templates/cogrpc-deploy.yml
@@ -34,8 +34,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "relaynet-internet-gateway.image" . }}
           imagePullPolicy: IfNotPresent
-          command:
-            - node
+          args:
             - build/main/bin/cogrpc-server.js
           env:
             - name: PUBLIC_ADDRESS

--- a/chart/templates/crcin-deploy.yml
+++ b/chart/templates/crcin-deploy.yml
@@ -33,8 +33,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "relaynet-internet-gateway.image" . }}
           imagePullPolicy: IfNotPresent
-          command:
-            - node
+          args:
             - build/main/bin/crc-queue-worker.js
           env:
             - name: WORKER_ID

--- a/chart/templates/keygen-job.yml
+++ b/chart/templates/keygen-job.yml
@@ -24,8 +24,7 @@ spec:
         - name: keygen
           image: {{ include "relaynet-internet-gateway.image" . }}
           imagePullPolicy: IfNotPresent
-          command:
-            - node
+          args:
             - build/main/bin/generate-keypairs.js
           envFrom:
             - configMapRef:

--- a/chart/templates/pdcout-deploy.yml
+++ b/chart/templates/pdcout-deploy.yml
@@ -31,8 +31,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "relaynet-internet-gateway.image" . }}
           imagePullPolicy: IfNotPresent
-          command:
-            - node
+          args:
             - build/main/bin/pdc-outgoing-queue-worker.js
           env:
             - name: POHTTP_ADDRESS

--- a/chart/templates/pohttp-deploy.yml
+++ b/chart/templates/pohttp-deploy.yml
@@ -33,8 +33,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "relaynet-internet-gateway.image" . }}
           imagePullPolicy: IfNotPresent
-          command:
-            - node
+          args:
             - build/main/bin/pohttp-server.js
           env:
             {{- if .Values.proxyRequestIdHeader }}

--- a/chart/templates/poweb-deploy.yml
+++ b/chart/templates/poweb-deploy.yml
@@ -34,8 +34,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "relaynet-internet-gateway.image" . }}
           imagePullPolicy: IfNotPresent
-          command:
-            - node
+          args:
             - build/main/bin/poweb-server.js
           env:
             {{- if .Values.proxyRequestIdHeader }}

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -22,4 +22,4 @@ We use log levels as follows:
 - `info`: Events for any outcome observed outside the gateway, or any unusual interaction with a backing service.
 - `warning`: Something has gone wrong but it's being handled gracefully. Triage can start on the next working day.
 - `error`: Something has gone wrong and triage must start within a few minutes. Wake up an SRE if necessary.
-- `fatal`: Not used.
+- `fatal`: A process has crashed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7862,11 +7862,6 @@
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
-    "make-promises-safe": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/make-promises-safe/-/make-promises-safe-5.1.0.tgz",
-      "integrity": "sha512-AfdZ49rtyhQR/6cqVKGoH7y4ql7XkS5HJI1lZm0/5N6CQosy1eYbBJ/qbhkKHzo17UH7M918Bysf6XB9f3kS1g=="
-    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "grpc": "^1.24.4",
     "grpc-health-check": "^1.8.0",
     "it-pipe": "^1.1.0",
-    "make-promises-safe": "^5.1.0",
     "mongoose": "^5.10.18",
     "node-nats-streaming": "^0.3.2",
     "pino": "^6.11.0",

--- a/src/bin/cogrpc-server.ts
+++ b/src/bin/cogrpc-server.ts
@@ -1,6 +1,3 @@
-// tslint:disable-next-line:no-var-requires
-require('make-promises-safe');
-
 import { runServer } from '../services/cogrpc/server';
 
 runServer();

--- a/src/bin/crc-queue-worker.ts
+++ b/src/bin/crc-queue-worker.ts
@@ -4,6 +4,3 @@ import { processIncomingCrcCargo } from '../services/crcQueueWorker';
 
 const WORKER_ID = getEnvVar('WORKER_ID').required().asString();
 processIncomingCrcCargo(WORKER_ID);
-
-// tslint:disable-next-line:no-console
-console.log(`Starting queue worker ${WORKER_ID}`);

--- a/src/bin/crc-queue-worker.ts
+++ b/src/bin/crc-queue-worker.ts
@@ -1,6 +1,3 @@
-// tslint:disable-next-line:no-var-requires
-require('make-promises-safe');
-
 import { get as getEnvVar } from 'env-var';
 
 import { processIncomingCrcCargo } from '../services/crcQueueWorker';

--- a/src/bin/generate-keypairs.ts
+++ b/src/bin/generate-keypairs.ts
@@ -1,8 +1,4 @@
 // tslint:disable:no-console
-
-// tslint:disable-next-line:no-var-requires
-require('make-promises-safe');
-
 import {
   Certificate,
   generateECDHKeyPair,

--- a/src/bin/pdc-outgoing-queue-worker.ts
+++ b/src/bin/pdc-outgoing-queue-worker.ts
@@ -1,6 +1,3 @@
-// tslint:disable-next-line:no-var-requires
-require('make-promises-safe');
-
 import { get as getEnvVar } from 'env-var';
 
 import { processInternetBoundParcels } from '../services/internetBoundParcelsQueueWorker';

--- a/src/bin/pohttp-server.ts
+++ b/src/bin/pohttp-server.ts
@@ -1,6 +1,3 @@
-// tslint:disable-next-line:no-var-requires
-require('make-promises-safe');
-
 import { makeServer } from '../services/pohttp/server';
 import { runFastify } from '../utilities/fastify';
 

--- a/src/bin/poweb-server.ts
+++ b/src/bin/poweb-server.ts
@@ -1,6 +1,3 @@
-// tslint:disable-next-line:no-var-requires
-require('make-promises-safe');
-
 import { makeServer } from '../services/poweb/server';
 import { runFastify } from '../utilities/fastify';
 

--- a/src/services/cogrpc/server.ts
+++ b/src/services/cogrpc/server.ts
@@ -4,6 +4,7 @@ import { KeyCertPair, Server, ServerCredentials } from 'grpc';
 import grpcHealthCheck from 'grpc-health-check';
 import { Logger } from 'pino';
 import * as selfsigned from 'selfsigned';
+import { configureExitHandling } from '../../utilities/exitHandling';
 
 import { makeLogger } from '../../utilities/logging';
 import { MAX_RAMF_MESSAGE_SIZE } from '../constants';
@@ -19,6 +20,9 @@ const MAX_CONNECTION_AGE_GRACE_SECONDS = 30;
 const MAX_CONNECTION_IDLE_SECONDS = 5;
 
 export async function runServer(logger?: Logger): Promise<void> {
+  const baseLogger = logger ?? makeLogger();
+  configureExitHandling(baseLogger);
+
   const gatewayKeyIdBase64 = getEnvVar('GATEWAY_KEY_ID').required().asString();
   const publicAddress = getEnvVar('PUBLIC_ADDRESS').required().asString();
   const parcelStoreBucket = getEnvVar('OBJECT_STORE_BUCKET').required().asString();
@@ -34,7 +38,6 @@ export async function runServer(logger?: Logger): Promise<void> {
     'grpc.max_receive_message_length': MAX_RECEIVED_MESSAGE_LENGTH,
   });
 
-  const baseLogger = logger ?? makeLogger();
   const serviceImplementation = await makeServiceImplementation({
     baseLogger,
     gatewayKeyIdBase64,

--- a/src/services/crcQueueWorker.ts
+++ b/src/services/crcQueueWorker.ts
@@ -37,11 +37,10 @@ export async function processIncomingCrcCargo(workerName: string): Promise<void>
     undefined,
     '-consumer',
   );
-  await pipe(queueConsumer, makeCargoProcessor(workerName, natsStreamingClient, logger));
+  await pipe(queueConsumer, makeCargoProcessor(natsStreamingClient, logger));
 }
 
 function makeCargoProcessor(
-  workerName: string,
   natsStreamingClient: NatsStreamingClient,
   logger: Logger,
 ): (messages: AsyncIterable<Message>) => Promise<void> {
@@ -58,7 +57,7 @@ function makeCargoProcessor(
         await processCargo(
           message,
           gateway,
-          logger.child({ worker: workerName }),
+          logger,
           parcelStore,
           mongooseConnection,
           natsStreamingClient,

--- a/src/services/crcQueueWorker.ts
+++ b/src/services/crcQueueWorker.ts
@@ -18,11 +18,16 @@ import { initVaultKeyStore } from '../backingServices/keyStores';
 import { createMongooseConnectionFromEnv } from '../backingServices/mongo';
 import { NatsStreamingClient } from '../backingServices/natsStreaming';
 import { initObjectStoreFromEnv } from '../backingServices/objectStorage';
+import { configureExitHandling } from '../utilities/exitHandling';
 import { makeLogger } from '../utilities/logging';
 import { MongoPublicKeyStore } from './MongoPublicKeyStore';
 import { ParcelStore } from './parcelStore';
 
 export async function processIncomingCrcCargo(workerName: string): Promise<void> {
+  const logger = makeLogger().child({ worker: workerName });
+  configureExitHandling(logger);
+  logger.info('Starting queue worker');
+
   const natsStreamingClient = NatsStreamingClient.initFromEnv(workerName);
 
   const queueConsumer = natsStreamingClient.makeQueueConsumer(
@@ -32,16 +37,15 @@ export async function processIncomingCrcCargo(workerName: string): Promise<void>
     undefined,
     '-consumer',
   );
-  await pipe(queueConsumer, makeCargoProcessor(workerName, natsStreamingClient));
+  await pipe(queueConsumer, makeCargoProcessor(workerName, natsStreamingClient, logger));
 }
 
 function makeCargoProcessor(
   workerName: string,
   natsStreamingClient: NatsStreamingClient,
+  logger: Logger,
 ): (messages: AsyncIterable<Message>) => Promise<void> {
   return async (messages) => {
-    const logger = makeLogger();
-
     const mongooseConnection = await createMongooseConnectionFromEnv();
     const gateway = new Gateway(initVaultKeyStore(), new MongoPublicKeyStore(mongooseConnection));
 

--- a/src/services/internetBoundParcelsQueueWorker.ts
+++ b/src/services/internetBoundParcelsQueueWorker.ts
@@ -5,6 +5,7 @@ import * as stan from 'node-nats-streaming';
 
 import { NatsStreamingClient } from '../backingServices/natsStreaming';
 import { initObjectStoreFromEnv } from '../backingServices/objectStorage';
+import { configureExitHandling } from '../utilities/exitHandling';
 import { makeLogger } from '../utilities/logging';
 import { ParcelStore, QueuedInternetBoundParcelMessage } from './parcelStore';
 
@@ -19,7 +20,9 @@ export async function processInternetBoundParcels(
   workerName: string,
   ownPohttpAddress: string,
 ): Promise<void> {
-  const logger = makeLogger();
+  const logger = makeLogger().child({ worker: workerName });
+  configureExitHandling(logger);
+  logger.info('Starting queue worker');
 
   const parcelStoreBucket = getEnvVar('OBJECT_STORE_BUCKET').required().asString();
   const parcelStore = new ParcelStore(initObjectStoreFromEnv(), parcelStoreBucket);

--- a/src/services/parcelCollection.spec.ts
+++ b/src/services/parcelCollection.spec.ts
@@ -1,5 +1,3 @@
-/* tslint:disable:no-let */
-
 import { generateRSAKeyPair, Parcel, ParcelCollectionAck } from '@relaycorp/relaynet-core';
 import * as typegoose from '@typegoose/typegoose';
 import { Connection } from 'mongoose';

--- a/src/services/parcelStore.ts
+++ b/src/services/parcelStore.ts
@@ -9,10 +9,10 @@ import uuid from 'uuid-random';
 
 import { NatsStreamingClient } from '../backingServices/natsStreaming';
 import { initObjectStoreFromEnv } from '../backingServices/objectStorage';
+import { BasicLogger } from '../utilities/types';
 import { convertDateToTimestamp, sha256Hex } from '../utils';
 import { retrieveOwnCertificates } from './certs';
 import { recordParcelCollection, wasParcelCollected } from './parcelCollection';
-import { BasicLogger } from './types';
 
 const GATEWAY_BOUND_OBJECT_KEY_PREFIX = 'parcels/gateway-bound';
 const ENDPOINT_BOUND_OBJECT_KEY_PREFIX = 'parcels/endpoint-bound';

--- a/src/services/pohttp/routes.spec.ts
+++ b/src/services/pohttp/routes.spec.ts
@@ -15,6 +15,8 @@ import {
 import { ParcelStore } from '../parcelStore';
 import { makeServer } from './server';
 
+jest.mock('../../utilities/exitHandling');
+
 const mockFastifyMongooseObject = { db: { what: 'The mongoose.Connection' } as any, ObjectId: {} };
 mockFastifyMongoose(mockFastifyMongooseObject);
 

--- a/src/services/pohttp/server.spec.ts
+++ b/src/services/pohttp/server.spec.ts
@@ -2,6 +2,8 @@ import { mockSpy } from '../../_test_utils';
 import * as fastifyUtils from '../../utilities/fastify';
 import { makeServer } from './server';
 
+jest.mock('../../utilities/exitHandling');
+
 const mockFastifyInstance = {};
 const mockConfigureFastify = mockSpy(
   jest.spyOn(fastifyUtils, 'configureFastify'),

--- a/src/services/poweb/healthcheck.spec.ts
+++ b/src/services/poweb/healthcheck.spec.ts
@@ -2,6 +2,8 @@ import { testDisallowedMethods } from '../_test_utils';
 import { setUpCommonFixtures } from './_test_utils';
 import { makeServer } from './server';
 
+jest.mock('../../utilities/exitHandling');
+
 describe('healthcheck', () => {
   setUpCommonFixtures();
 

--- a/src/services/poweb/parcelCollection.spec.ts
+++ b/src/services/poweb/parcelCollection.spec.ts
@@ -34,6 +34,8 @@ import { setUpCommonFixtures } from './_test_utils';
 import { makeWebSocketServer } from './parcelCollection';
 import { WebSocketCode } from './websockets';
 
+jest.mock('../../utilities/exitHandling');
+
 const REQUEST_ID_HEADER = 'X-Request';
 
 const getFixtures = setUpCommonFixtures();

--- a/src/services/poweb/parcelDelivery.spec.ts
+++ b/src/services/poweb/parcelDelivery.spec.ts
@@ -11,6 +11,8 @@ import { setUpCommonFixtures } from './_test_utils';
 import { CONTENT_TYPES } from './contentTypes';
 import { makeServer } from './server';
 
+jest.mock('../../utilities/exitHandling');
+
 const ENDPOINT_URL = '/v1/parcels';
 
 const getFixtures = setUpCommonFixtures();

--- a/src/services/poweb/preRegistration.spec.ts
+++ b/src/services/poweb/preRegistration.spec.ts
@@ -1,5 +1,3 @@
-// tslint:disable:no-let
-
 import { PrivateNodeRegistrationAuthorization } from '@relaycorp/relaynet-core';
 import bufferToArray from 'buffer-to-arraybuffer';
 
@@ -7,6 +5,8 @@ import { testDisallowedMethods } from '../_test_utils';
 import { setUpCommonFixtures } from './_test_utils';
 import { CONTENT_TYPES } from './contentTypes';
 import { makeServer } from './server';
+
+jest.mock('../../utilities/exitHandling');
 
 const ENDPOINT_URL = '/v1/pre-registrations';
 

--- a/src/services/poweb/registration.spec.ts
+++ b/src/services/poweb/registration.spec.ts
@@ -21,6 +21,8 @@ import { FixtureSet, setUpCommonFixtures } from './_test_utils';
 import { CONTENT_TYPES } from './contentTypes';
 import { makeServer } from './server';
 
+jest.mock('../../utilities/exitHandling');
+
 const ENDPOINT_URL = '/v1/nodes';
 
 const getFixtures = setUpCommonFixtures();

--- a/src/services/poweb/server.spec.ts
+++ b/src/services/poweb/server.spec.ts
@@ -6,6 +6,8 @@ import { setUpCommonFixtures } from './_test_utils';
 import RouteOptions from './RouteOptions';
 import { makeServer } from './server';
 
+jest.mock('../../utilities/exitHandling');
+
 const getFixtures = setUpCommonFixtures();
 
 const mockFastifyInstance = {};

--- a/src/services/poweb/server.spec.ts
+++ b/src/services/poweb/server.spec.ts
@@ -1,3 +1,5 @@
+import pino from 'pino';
+
 import { mockSpy } from '../../_test_utils';
 import * as fastifyUtils from '../../utilities/fastify';
 import { setUpCommonFixtures } from './_test_utils';
@@ -29,7 +31,7 @@ describe('makeServer', () => {
   });
 
   test('Any explicit logger should be honored', async () => {
-    const logger: fastifyUtils.FastifyLogger = { level: 'debug' };
+    const logger = pino();
 
     await makeServer(logger);
 

--- a/src/services/poweb/server.ts
+++ b/src/services/poweb/server.ts
@@ -1,9 +1,10 @@
 import { UnboundKeyPair } from '@relaycorp/relaynet-core';
 import { get as getEnvVar } from 'env-var';
 import { FastifyInstance, FastifyPluginCallback } from 'fastify';
+import { Logger } from 'pino';
 
 import { initVaultKeyStore } from '../../backingServices/keyStores';
-import { configureFastify, FastifyLogger } from '../../utilities/fastify';
+import { configureFastify } from '../../utilities/fastify';
 import healthcheck from './healthcheck';
 import parcelCollection from './parcelCollection';
 import parcelDelivery from './parcelDelivery';
@@ -24,7 +25,7 @@ const ROUTES: ReadonlyArray<FastifyPluginCallback<RouteOptions>> = [
  *
  * This function doesn't call .listen() so we can use .inject() for testing purposes.
  */
-export async function makeServer(logger?: FastifyLogger): Promise<FastifyInstance> {
+export async function makeServer(logger?: Logger): Promise<FastifyInstance> {
   return configureFastify(
     ROUTES,
     {

--- a/src/types/make-promises-safe.d.ts
+++ b/src/types/make-promises-safe.d.ts
@@ -1,0 +1,3 @@
+declare module 'make-promises-safe' {
+  export let logError: (error: Error) => void;
+}

--- a/src/types/make-promises-safe.d.ts
+++ b/src/types/make-promises-safe.d.ts
@@ -1,3 +1,0 @@
-declare module 'make-promises-safe' {
-  export let logError: (error: Error) => void;
-}

--- a/src/utilities/exitHandling.spec.ts
+++ b/src/utilities/exitHandling.spec.ts
@@ -1,11 +1,8 @@
-import makePromisesSafe from 'make-promises-safe';
 import pino from 'pino';
 
 import { makeMockLogging, MockLogging, mockSpy, partialPinoLog } from '../_test_utils';
 import { getMockContext } from '../services/_test_utils';
 import { configureExitHandling } from './exitHandling';
-
-jest.mock('make-promises-safe');
 
 const ERROR = new Error('Oh noes');
 
@@ -51,19 +48,6 @@ describe('configureExitHandling', () => {
       handler(ERROR);
 
       expect(mockProcessExit).toBeCalledWith(1);
-    });
-  });
-
-  describe('make-promises-safe logger', () => {
-    test('Error should be logged as fatal', () => {
-      makePromisesSafe.logError(ERROR);
-
-      expect(mockLogging.logs).toBeEmpty();
-      expect(mockFinalLogging.logs).toContainEqual(
-        partialPinoLog('fatal', 'unhandledRejection', {
-          err: expect.objectContaining({ message: ERROR.message }),
-        }),
-      );
     });
   });
 });

--- a/src/utilities/exitHandling.spec.ts
+++ b/src/utilities/exitHandling.spec.ts
@@ -31,7 +31,7 @@ describe('configureExitHandling', () => {
 
       handler(ERROR);
 
-      expect(mockLogging.logs).toBeEmpty()
+      expect(mockLogging.logs).toBeEmpty();
       expect(mockFinalLogging.logs).toContainEqual(
         partialPinoLog('fatal', 'uncaughtException', {
           err: expect.objectContaining({ message: ERROR.message }),

--- a/src/utilities/exitHandling.spec.ts
+++ b/src/utilities/exitHandling.spec.ts
@@ -1,0 +1,56 @@
+import pino from 'pino';
+
+import { makeMockLogging, MockLogging, mockSpy, partialPinoLog } from '../_test_utils';
+import { getMockContext } from '../services/_test_utils';
+import { configureExitHandling } from './exitHandling';
+
+const ERROR = new Error('Oh noes');
+
+let mockLogging: MockLogging;
+let mockFinalLogging: MockLogging;
+beforeEach(() => {
+  mockLogging = makeMockLogging();
+  mockFinalLogging = makeMockLogging();
+});
+
+const mockProcessOn = mockSpy(jest.spyOn(process, 'on'));
+const mockProcessExit = mockSpy(jest.spyOn(process, 'exit'));
+const mockPinoFinal = mockSpy(jest.spyOn(pino, 'final'), (_, handler) => (err: Error) =>
+  handler(err, mockFinalLogging.logger),
+);
+
+describe('configureExitHandling', () => {
+  beforeEach(() => {
+    configureExitHandling(mockLogging.logger);
+  });
+
+  describe('uncaughtException', () => {
+    test('Error should be logged as fatal', () => {
+      const call = getMockContext(mockProcessOn).calls[0];
+      const handler = call[1];
+
+      handler(ERROR);
+
+      expect(mockLogging.logs).toBeEmpty()
+      expect(mockFinalLogging.logs).toContainEqual(
+        partialPinoLog('fatal', 'uncaughtException', {
+          err: expect.objectContaining({ message: ERROR.message }),
+        }),
+      );
+    });
+
+    test('Pino logger should be final', () => {
+      expect(mockPinoFinal).toBeCalledWith(mockLogging.logger, expect.toBeFunction());
+    });
+
+    test('Process should exit with code 1', () => {
+      const call = getMockContext(mockProcessOn).calls[0];
+      const handler = call[1];
+      expect(mockProcessExit).not.toBeCalled();
+
+      handler(ERROR);
+
+      expect(mockProcessExit).toBeCalledWith(1);
+    });
+  });
+});

--- a/src/utilities/exitHandling.ts
+++ b/src/utilities/exitHandling.ts
@@ -1,4 +1,3 @@
-import makePromisesSafe from 'make-promises-safe';
 import pino, { Logger } from 'pino';
 
 export function configureExitHandling(logger: Logger): void {
@@ -10,9 +9,4 @@ export function configureExitHandling(logger: Logger): void {
       process.exit(1);
     }),
   );
-
-  // tslint:disable-next-line:no-object-mutation
-  makePromisesSafe.logError = pino.final(logger, (err, finalLogger) => {
-    finalLogger.fatal({ err }, 'unhandledRejection');
-  });
 }

--- a/src/utilities/exitHandling.ts
+++ b/src/utilities/exitHandling.ts
@@ -1,3 +1,4 @@
+import makePromisesSafe from 'make-promises-safe';
 import pino, { Logger } from 'pino';
 
 export function configureExitHandling(logger: Logger): void {
@@ -9,4 +10,8 @@ export function configureExitHandling(logger: Logger): void {
       process.exit(1);
     }),
   );
+
+  makePromisesSafe.logError = pino.final(logger, (err, finalLogger) => {
+    finalLogger.fatal({ err }, 'unhandledRejection');
+  });
 }

--- a/src/utilities/exitHandling.ts
+++ b/src/utilities/exitHandling.ts
@@ -1,0 +1,12 @@
+import pino, { Logger } from 'pino';
+
+export function configureExitHandling(logger: Logger): void {
+  process.on(
+    'uncaughtException',
+    pino.final(logger, (err, finalLogger) => {
+      finalLogger.fatal({ err }, 'uncaughtException');
+
+      process.exit(1);
+    }),
+  );
+}

--- a/src/utilities/exitHandling.ts
+++ b/src/utilities/exitHandling.ts
@@ -11,6 +11,7 @@ export function configureExitHandling(logger: Logger): void {
     }),
   );
 
+  // tslint:disable-next-line:no-object-mutation
   makePromisesSafe.logError = pino.final(logger, (err, finalLogger) => {
     finalLogger.fatal({ err }, 'unhandledRejection');
   });

--- a/src/utilities/fastify.spec.ts
+++ b/src/utilities/fastify.spec.ts
@@ -5,6 +5,7 @@ import pino from 'pino';
 import { mockSpy, MONGO_ENV_VARS } from '../_test_utils';
 import { configureMockEnvVars, getMockContext, getMockInstance } from '../services/_test_utils';
 import { MAX_RAMF_MESSAGE_SIZE } from '../services/constants';
+import * as exitHandling from './exitHandling';
 import { configureFastify, runFastify } from './fastify';
 import * as logging from './logging';
 
@@ -25,6 +26,8 @@ const mockEnvVars = configureMockEnvVars(MONGO_ENV_VARS);
 
 const mockMakeLogger = mockSpy(jest.spyOn(logging, 'makeLogger'));
 
+const mockExitHandler = mockSpy(jest.spyOn(exitHandling, 'configureExitHandling'));
+
 const dummyRoutes: FastifyPluginCallback = () => null;
 
 describe('configureFastify', () => {
@@ -34,6 +37,8 @@ describe('configureFastify', () => {
     expect(mockMakeLogger).toBeCalledWith();
     const logger = getMockContext(mockMakeLogger).results[0].value;
     expect(fastify).toBeCalledWith(expect.objectContaining({ logger }));
+
+    expect(mockExitHandler).toBeCalledWith(logger);
   });
 
   test('Custom logger should be honoured', () => {
@@ -45,6 +50,7 @@ describe('configureFastify', () => {
         logger: customLogger,
       }),
     );
+    expect(mockExitHandler).toBeCalledWith(customLogger);
   });
 
   test('X-Request-Id should be the default request id header', () => {

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -16,5 +16,6 @@ export interface BasicLogger {
   readonly info: LogMethod;
   readonly warn: LogMethod;
   readonly error: LogMethod;
+  readonly fatal: LogMethod;
   readonly child: (bindings: Bindings) => BasicLogger;
 }


### PR DESCRIPTION
Part of https://github.com/relaycorp/cloud-gateway/issues/10

TODO

- [x] Configure unhandledRejection: https://github.com/pinojs/pino/blob/master/docs/help.md#exit-logging
- [x] Configure `make-promises-safe` logger.
- [x] Configure fastify servers
- [x] Configure CogRPC server
- [x] Configure CRC queue
- [x] Configure PDC queue