### PR TITLE
fix(pdcout): Gracefully deal with missing parcel objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1462,12 +1462,12 @@
       }
     },
     "@relaycorp/object-storage": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@relaycorp/object-storage/-/object-storage-1.3.9.tgz",
-      "integrity": "sha512-IqZnTB/M02iAYLxfGSqwxElCvlYAO5sFEWAfbsmb+aCxXJHcN+AZDnjM/g57OzEBkq6DKMVv5fAjvcNkDIvYnA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@relaycorp/object-storage/-/object-storage-1.4.0.tgz",
+      "integrity": "sha512-m7YCu06iMwUweYkboHqJZZR7xSwVLc7K5oI9gOkizXWm1myfVzG5n/4J3+BhqjpXH4YXleiNb3DAbuy4cZfCRA==",
       "requires": {
-        "@google-cloud/storage": "^5.8.0",
-        "aws-sdk": "^2.853.0"
+        "@google-cloud/storage": "^5.8.1",
+        "aws-sdk": "^2.865.0"
       }
     },
     "@relaycorp/pino-cloud": {
@@ -2554,7 +2554,17 @@
     "asn1js": {
       "version": "2.0.26",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
-      "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ=="
+      "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
+      "requires": {
+        "pvutils": "^1.0.17"
+      },
+      "dependencies": {
+        "pvutils": {
+          "version": "1.0.17",
+          "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+          "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
+        }
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -2625,9 +2635,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.858.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.858.0.tgz",
-      "integrity": "sha512-VXNnGmPcZu4ZRc0yqw4F6d43edrMMKQwOmZX9/hQW/l5DFGqdGzvaDKljZyD1FHNbmaxXz09RfLzjVEmq+CVzA==",
+      "version": "2.866.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.866.0.tgz",
+      "integrity": "sha512-6Z581Ek2Yfm78NpeEFMNuSoyiYG7tipEaqfWNFR1AGyYheZwql4ajhzzlpWn91LBpdm7qcFldSNY9U0tKpKWNw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -3155,6 +3165,7 @@
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4646,6 +4657,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -6549,6 +6567,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@relaycorp/cogrpc": "^1.3.4",
     "@relaycorp/keystore-vault": "^1.2.1",
-    "@relaycorp/object-storage": "^1.3.9",
+    "@relaycorp/object-storage": "^1.4.0",
     "@relaycorp/pino-cloud": "^1.0.3",
     "@relaycorp/relaynet-core": "^1.42.7",
     "@relaycorp/relaynet-pohttp": "^1.6.2",

--- a/src/functionalTests/pdc_client.test.ts
+++ b/src/functionalTests/pdc_client.test.ts
@@ -88,12 +88,11 @@ async function queueParcel(parcel: Parcel): Promise<void> {
 }
 
 async function isParcelInStore(parcel: Parcel): Promise<boolean> {
-  try {
-    await OBJECT_STORAGE_CLIENT.getObject(makeParcelObjectKey(parcel.id), OBJECT_STORAGE_BUCKET);
-  } catch (_) {
-    return false;
-  }
-  return true;
+  const parcelObject = await OBJECT_STORAGE_CLIENT.getObject(
+    makeParcelObjectKey(parcel.id),
+    OBJECT_STORAGE_BUCKET,
+  );
+  return !!parcelObject;
 }
 
 function makeParcelObjectKey(parcelId: string): string {

--- a/src/parcelStore.spec.ts
+++ b/src/parcelStore.spec.ts
@@ -970,7 +970,7 @@ describe('makeActiveParcelRetriever', () => {
       extra: null,
       key: 'prefix/deleted.parcel',
     };
-    getMockInstance(MOCK_OBJECT_STORE_CLIENT.getObject).mockResolvedValue(undefined);
+    getMockInstance(MOCK_OBJECT_STORE_CLIENT.getObject).mockResolvedValue(null);
 
     await expect(
       pipe(

--- a/src/parcelStore.spec.ts
+++ b/src/parcelStore.spec.ts
@@ -615,6 +615,14 @@ describe('retrieveEndpointBoundParcel', () => {
 
     expect(retrievedParcelSerialized).toEqual(parcelSerialized);
   });
+
+  test('Nothing should be returned if the object does not exist', async () => {
+    getMockInstance(MOCK_OBJECT_STORE_CLIENT.getObject).mockResolvedValue(null);
+
+    const retrievedParcelSerialized = await store.retrieveEndpointBoundParcel('key');
+
+    expect(retrievedParcelSerialized).toBeNull();
+  });
 });
 
 describe('storeEndpointBoundParcel', () => {
@@ -962,8 +970,7 @@ describe('makeActiveParcelRetriever', () => {
       extra: null,
       key: 'prefix/deleted.parcel',
     };
-    const error = new Error('That was deleted');
-    getMockInstance(MOCK_OBJECT_STORE_CLIENT.getObject).mockRejectedValue(error);
+    getMockInstance(MOCK_OBJECT_STORE_CLIENT.getObject).mockResolvedValue(undefined);
 
     await expect(
       pipe(
@@ -978,7 +985,6 @@ describe('makeActiveParcelRetriever', () => {
         'info',
         'Parcel object could not be found; it could have been deleted since keys were retrieved',
         {
-          err: expect.objectContaining({ message: error.message }),
           parcelObjectKey: parcelObjectMetadata.key,
         },
       ),

--- a/src/queueWorkers/pdcOutgoing.ts
+++ b/src/queueWorkers/pdcOutgoing.ts
@@ -52,6 +52,7 @@ export async function processInternetBoundParcels(
 
   async function deliverParcels(activeParcels: AsyncIterable<ActiveParcelData>): Promise<void> {
     for await (const parcelData of activeParcels) {
+      const parcelAwareLogger = logger.child({ parcelObjectKey: parcelData.parcelObjectKey });
       const parcelSerialized = await parcelStore.retrieveEndpointBoundParcel(
         parcelData.parcelObjectKey,
       );
@@ -64,24 +65,15 @@ export async function processInternetBoundParcels(
       } catch (err) {
         wasParcelDelivered = false;
         if (err instanceof PoHTTPInvalidParcelError) {
-          logger.info(
-            { err, parcelObjectKey: parcelData.parcelObjectKey },
-            'Parcel was rejected as invalid',
-          );
+          parcelAwareLogger.info({ err }, 'Parcel was rejected as invalid');
         } else {
-          logger.warn(
-            { err, parcelObjectKey: parcelData.parcelObjectKey },
-            'Failed to deliver parcel',
-          );
+          parcelAwareLogger.warn({ err }, 'Failed to deliver parcel');
           continue;
         }
       }
 
       if (wasParcelDelivered) {
-        logger.debug(
-          { parcelObjectKey: parcelData.parcelObjectKey },
-          'Parcel was successfully delivered',
-        );
+        parcelAwareLogger.debug('Parcel was successfully delivered');
       }
 
       await parcelStore.deleteEndpointBoundParcel(parcelData.parcelObjectKey);

--- a/src/queueWorkers/pdcOutgoing.ts
+++ b/src/queueWorkers/pdcOutgoing.ts
@@ -57,6 +57,12 @@ export async function processInternetBoundParcels(
         parcelData.parcelObjectKey,
       );
 
+      if (!parcelSerialized) {
+        parcelAwareLogger.warn('Parcel object could not be found');
+        parcelData.ack();
+        continue;
+      }
+
       let wasParcelDelivered = true;
       try {
         await deliverParcel(parcelData.parcelRecipientAddress, parcelSerialized, {


### PR DESCRIPTION
Fixes https://console.cloud.google.com/errors/CJ69k8PhgvTNKQ?time=P30D&project=relaycorp-cloud-gateway

```
Error: No such object: gateway-frankfurt-messages-6baa1b/parcels/endpoint-bound/<redacted>/<redacted>/7a31ddf1-7671-49f4-a6e0-7c8e08cf09a1
    at new ApiError (/opt/gw/node_modules/@google-cloud/common/build/src/util.js:59:15)
    at Util.parseHttpRespBody (/opt/gw/node_modules/@google-cloud/common/build/src/util.js:194:38)
    at Util.handleResp (/opt/gw/node_modules/@google-cloud/common/build/src/util.js:135:117)
    at /opt/gw/node_modules/@google-cloud/common/build/src/util.js:434:22
    at onResponse (/opt/gw/node_modules/retry-request/index.js:214:7)
    at /opt/gw/node_modules/teeny-request/build/src/index.js:219:13
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

```