### PR TITLE
fix(PoWeb): Use HTTP 422 when parcel is well-formed but invalid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1423,18 +1423,18 @@
       }
     },
     "@relaycorp/relaynet-poweb": {
-      "version": "1.3.19",
-      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-poweb/-/relaynet-poweb-1.3.19.tgz",
-      "integrity": "sha512-hcrbAYe00r93tBJ7zSFo8nLIkaAEzn6ldyn7bf2E5BrNdC0fzQxXUwYgmL+Qs40pdgVWXIaqh6w1LYr7e68Uiw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-poweb/-/relaynet-poweb-1.5.2.tgz",
+      "integrity": "sha512-MmSQIpj7KLq1da21i2oKj92DKhVqvlhMzXqAGAS7vxs+1W/2SqOD3TP1Y2Eu+bTQwJ7mcUnu0963CJ7u7Q7vdg==",
       "dev": true,
       "requires": {
-        "@relaycorp/relaynet-core": ">= 1.41.0 < 2",
+        "@relaycorp/relaynet-core": "^1.43.0",
         "axios": "^0.21.1",
         "buffer-to-arraybuffer": "0.0.6",
         "it-pipe": "^1.1.0",
-        "stream-to-it": "^0.2.2",
+        "stream-to-it": "^0.2.3",
         "verror": "^1.10.0",
-        "ws": "^7.4.4"
+        "ws": "^7.4.5"
       }
     },
     "@relaycorp/shared-config": {
@@ -11933,7 +11933,7 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": false,
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=12"
   },
   "devDependencies": {
-    "@relaycorp/relaynet-poweb": "^1.3.19",
+    "@relaycorp/relaynet-poweb": "^1.5.2",
     "@relaycorp/shared-config": "^1.4.13",
     "@relaycorp/ws-mock": "^1.5.0",
     "@semantic-release/exec": "^5.0.0",

--- a/src/functionalTests/internet_e2e.test.ts
+++ b/src/functionalTests/internet_e2e.test.ts
@@ -11,8 +11,9 @@ import {
   SessionEnvelopedData,
   SessionlessEnvelopedData,
   Signer,
+  StreamingMode,
 } from '@relaycorp/relaynet-core';
-import { PoWebClient, StreamingMode } from '@relaycorp/relaynet-poweb';
+import { PoWebClient } from '@relaycorp/relaynet-poweb';
 import bufferToArray from 'buffer-to-arraybuffer';
 import { get as getEnvVar } from 'env-var';
 import pipe from 'it-pipe';

--- a/src/functionalTests/poweb_server.test.ts
+++ b/src/functionalTests/poweb_server.test.ts
@@ -6,13 +6,13 @@ import {
   Parcel,
   PrivateNodeRegistrationRequest,
   Signer,
+  StreamingMode,
 } from '@relaycorp/relaynet-core';
 import {
   ParcelDeliveryError,
   PoWebClient,
   RefusedParcelError,
   ServerError,
-  StreamingMode,
 } from '@relaycorp/relaynet-poweb';
 import pipe from 'it-pipe';
 

--- a/src/services/poweb/parcelCollection.spec.ts
+++ b/src/services/poweb/parcelCollection.spec.ts
@@ -7,8 +7,8 @@ import {
   InvalidMessageError,
   ParcelDelivery,
   Signer,
+  StreamingMode,
 } from '@relaycorp/relaynet-core';
-import { StreamingMode } from '@relaycorp/relaynet-poweb';
 import { CloseFrame, createMockWebSocketStream, MockClient } from '@relaycorp/ws-mock';
 import AbortController from 'abort-controller';
 import bufferToArray from 'buffer-to-arraybuffer';

--- a/src/services/poweb/parcelDelivery.spec.ts
+++ b/src/services/poweb/parcelDelivery.spec.ts
@@ -143,7 +143,7 @@ test('Malformed parcels should be refused with an HTTP 400 response', async () =
   expect(fixtures.parcelStore.storeParcelFromPeerGateway).not.toBeCalled();
 });
 
-test('Well-formed yet invalid parcels should be refused with an HTTP 403 response', async () => {
+test('Well-formed yet invalid parcels should be refused with an HTTP 422 response', async () => {
   const logging = makeMockLogging();
   const fastify = await makeServer(logging.logger);
   const fixtures = getFixtures();
@@ -161,7 +161,7 @@ test('Well-formed yet invalid parcels should be refused with an HTTP 403 respons
     makeAuthorizationHeaderValue(countersignature),
   );
 
-  expect(response).toHaveProperty('statusCode', 403);
+  expect(response).toHaveProperty('statusCode', 422);
   expect(JSON.parse(response.payload)).toHaveProperty('message', 'Parcel is invalid');
   expect(logging.logs).toContainEqual(
     partialPinoLog('info', 'Invalid parcel', {

--- a/src/services/poweb/parcelDelivery.ts
+++ b/src/services/poweb/parcelDelivery.ts
@@ -82,7 +82,7 @@ export default async function registerRoutes(
       } catch (err) {
         if (err instanceof InvalidMessageError) {
           parcelAwareLogger.info({ err }, 'Invalid parcel');
-          return reply.code(403).send({ message: 'Parcel is invalid' });
+          return reply.code(422).send({ message: 'Parcel is invalid' });
         }
 
         parcelAwareLogger.error({ err }, 'Failed to save parcel');


### PR DESCRIPTION
See:

- https://github.com/AwalaNetwork/specs/commit/f4ef055baa67e1808efdb63be644592e5c052646
- https://github.com/relaycorp/relaynet-poweb-js/pull/129
