### PR TITLE
chore: Move Jest config file for functional tests into test suite directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm test
 
 First, run `skaffold delete` to ensure you have a clean fixture and then `skaffold run` to deploy the chart against which you'll run the tests.
 
-Again, you can run the tests selectively from your IDE (using `jest.config.functional.js` as the Jest configuration), or run the whole suite with:
+Again, you can run the tests selectively from your IDE, or run the whole suite with:
 
 ```bash
 npm run test:functional

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "fix:tslint": "tslint --fix --project .",
     "test": "run-s static-checks test:unit",
     "test:unit": "jest --coverage",
-    "test:functional": "jest --config jest.config.functional.js --runInBand --detectOpenHandles",
+    "test:functional": "jest --config src/functionalTests/jest.config.js --runInBand --detectOpenHandles",
     "static-checks": "run-p static-checks:*",
     "static-checks:lint": "tslint --project .",
     "static-checks:prettier": "prettier \"src/**/*.ts\" --list-different",

--- a/src/functionalTests/jest.config.js
+++ b/src/functionalTests/jest.config.js
@@ -1,12 +1,12 @@
-const mainJestConfig = require('./jest.config');
+const mainJestConfig = require('../../jest.config');
 
 module.exports = {
   moduleFileExtensions: mainJestConfig.moduleFileExtensions,
   preset: mainJestConfig.preset,
-  roots: ['src/functionalTests'],
+  roots: ['.'],
   testEnvironment: mainJestConfig.testEnvironment,
   setupFilesAfterEnv: [
     ...mainJestConfig.setupFilesAfterEnv,
-    './src/functionalTests/jest.setup.ts',
+    './jest.setup.ts',
   ],
 };


### PR DESCRIPTION
So that WebStorm and other IDEs can use the right config file automatically.
