### PR TITLE
fix(PoWeb): Allow private gateways with multiple certificates to collect parcels

### DIFF
--- a/src/services/poweb/parcelCollection.spec.ts
+++ b/src/services/poweb/parcelCollection.spec.ts
@@ -37,7 +37,7 @@ import { ParcelStore, ParcelStreamMessage } from '../../parcelStore';
 import * as certs from '../../pki';
 import { expectBuffersToEqual, getMockInstance } from '../_test_utils';
 import { setUpCommonFixtures } from './_test_utils';
-import { makeWebSocketServer } from './parcelCollection';
+import { makeWebSocketServer, PARCEL_COLLECTION_MAX_PAYLOAD_OCTETS } from './parcelCollection';
 import { WebSocketCode } from './websockets';
 
 jest.mock('../../utilities/exitHandling');
@@ -98,14 +98,14 @@ describe('WebSocket server configuration', () => {
     expect(wsServer.options.path).toEqual('/v1/parcel-collection');
   });
 
-  test('Maximum incoming payload size should be 2 kib', () => {
+  test('Maximum incoming payload size should honour PARCEL_COLLECTION_MAX_PAYLOAD_OCTETS', () => {
     const wsServer = makeWebSocketServer(
       getFixtures().getMongooseConnection(),
       REQUEST_ID_HEADER,
       mockLogging.logger,
     );
 
-    expect(wsServer.options.maxPayload).toEqual(2 * 1024);
+    expect(wsServer.options.maxPayload).toEqual(PARCEL_COLLECTION_MAX_PAYLOAD_OCTETS);
   });
 
   test('Clients should not be tracked', () => {

--- a/src/services/poweb/parcelCollection.ts
+++ b/src/services/poweb/parcelCollection.ts
@@ -28,8 +28,15 @@ import { ParcelStore, ParcelStreamMessage } from '../../parcelStore';
 import { retrieveOwnCertificates } from '../../pki';
 import { WebSocketCode } from './websockets';
 
-// The largest payload the client could send is the handshake response, which should be < 1.9 kib
-const MAX_PAYLOAD = 2 * 1024;
+/**
+ * Maximum size of each incoming message.
+ *
+ * ACK messages are tiny, but HandshakeResponse messages contain digital signatures with their
+ * respective signers' certificates. Keeping in mind that each certificate takes up around 1.9 kib
+ * and a private gateway could have 2-3 valid certificates (whilst order certificates are being
+ * rotated out), we should allow 6 kib.
+ */
+export const PARCEL_COLLECTION_MAX_PAYLOAD_OCTETS = 6 * 1024;
 
 const WEBSOCKET_PING_INTERVAL_MS = 5_000;
 
@@ -64,7 +71,7 @@ export function makeWebSocketServer(
     : { noServer: true };
   const wsServer = new WSServer({
     clientTracking: false,
-    maxPayload: MAX_PAYLOAD,
+    maxPayload: PARCEL_COLLECTION_MAX_PAYLOAD_OCTETS,
     path: '/v1/parcel-collection',
     ...serverOptions,
   });


### PR DESCRIPTION
This could happen whilst 1+ older (yet still valid) certificates are being rotated out.