### PR TITLE
chore: Bring unit test coverage back to 100%

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,7 +21,7 @@ module.exports = {
   collectCoverage: false,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ["src/services/**/*.ts"],
+  collectCoverageFrom: ["src/**/*.ts"],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "coverage",
@@ -29,6 +29,7 @@ module.exports = {
   // An array of regexp pattern strings used to skip coverage collection
   coveragePathIgnorePatterns: [
     "_test_utils\.ts",
+    "/bin",
     "/functionalTests",
     "/types",
     "/index\.ts",

--- a/src/queueWorkers/pdcOutgoing.spec.ts
+++ b/src/queueWorkers/pdcOutgoing.spec.ts
@@ -299,6 +299,23 @@ describe('processInternetBoundParcels', () => {
     expect(MOCK_DELETE_INTERNET_PARCEL).toBeCalled();
   });
 
+  test('Unknown deliveryAttempts should be treated as no prior attempts', async () => {
+    const err = new pohttp.PoHTTPError('Server is down');
+    getMockInstance(pohttp.deliverParcel).mockRejectedValue(err);
+    const message = mockStanMessage(
+      Buffer.from(JSON.stringify({ ...QUEUE_MESSAGE_DATA, deliveryAttempts: undefined })),
+    );
+    MOCK_NATS_CLIENT.makeQueueConsumer.mockReturnValue(arrayToAsyncIterable([message]));
+
+    await processInternetBoundParcels(WORKER_NAME, OWN_POHTTP_ADDRESS);
+
+    expect(MOCK_NATS_CLIENT.publishMessage).toBeCalledWith(
+      expect.toSatisfy((a) => JSON.parse(a).deliveryAttempts === 1),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   test('Non-PoHTTP errors should be propagated', async () => {
     const err = new Error('This is a bug');
     getMockInstance(pohttp.deliverParcel).mockRejectedValue(err);

--- a/src/queueWorkers/pdcOutgoing.spec.ts
+++ b/src/queueWorkers/pdcOutgoing.spec.ts
@@ -302,9 +302,11 @@ describe('processInternetBoundParcels', () => {
   test('Unknown deliveryAttempts should be treated as no prior attempts', async () => {
     const err = new pohttp.PoHTTPError('Server is down');
     getMockInstance(pohttp.deliverParcel).mockRejectedValue(err);
-    const message = mockStanMessage(
-      Buffer.from(JSON.stringify({ ...QUEUE_MESSAGE_DATA, deliveryAttempts: undefined })),
-    );
+    const messageData: QueuedInternetBoundParcelMessage = {
+      ...QUEUE_MESSAGE_DATA,
+      deliveryAttempts: undefined as any,
+    };
+    const message = mockStanMessage(Buffer.from(JSON.stringify(messageData)));
     MOCK_NATS_CLIENT.makeQueueConsumer.mockReturnValue(arrayToAsyncIterable([message]));
 
     await processInternetBoundParcels(WORKER_NAME, OWN_POHTTP_ADDRESS);


### PR DESCRIPTION
I accidentally configured Jest to only monitor `src/services/**/*.ts` instead of everything under `src/`. Fortunately, thanks to TDD, there's only one branch uncovered in the whole codebase.