### PR TITLE
chore(deps): Upgrade Mongo, Redis and Pong charts to v12, v16 and v3 respectively

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.10.0
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.0.1
+  version: 12.1.20
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts
   version: 0.7.2
@@ -19,6 +19,6 @@ dependencies:
   version: 2.10.10
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.0.0
-digest: sha256:9843e8c57add942f1d5313a678d829271b84ff8b3589357c9f51506a3f517aef
-generated: "2021-12-31T16:02:07.820319252Z"
+  version: 16.12.2
+digest: sha256:1920a069a07c64eed5b9ff8e7aa063fe83dad08659014c11f147b76e5b2c10a9
+generated: "2022-06-17T12:02:33.506895803+01:00"

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 0.7.2
 - name: relaynet-pong
   repository: https://h.cfcr.io/relaycorp/public
-  version: 2.10.10
+  version: 3.0.10
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.12.2
-digest: sha256:1920a069a07c64eed5b9ff8e7aa063fe83dad08659014c11f147b76e5b2c10a9
-generated: "2022-06-17T12:02:33.506895803+01:00"
+digest: sha256:97c6bbc30878fae714a1e93338e3b3864721c8b39a591e8a7b995009362f92b6
+generated: "2022-06-17T15:38:13.944529326+01:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
     tags: [gwDev]
     repository: https://helm.releases.hashicorp.com
   - name: mongodb
-    version: 10.0.1
+    version: 12.1.20
     tags: [gwDev]
     repository: https://charts.bitnami.com/bitnami
   - name: nats
@@ -42,6 +42,6 @@ dependencies:
     tags: [gwDev]
     repository: https://h.cfcr.io/relaycorp/public
   - name: redis
-    version: 12.0.0
+    version: 16.12.2
     tags: [gwDev]
     repository: https://charts.bitnami.com/bitnami

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
 
   # Pong app
   - name: relaynet-pong
-    version: 2.10.10
+    version: 3.0.10
     tags: [gwDev]
     repository: https://h.cfcr.io/relaycorp/public
   - name: redis

--- a/chart/values.dev.yml
+++ b/chart/values.dev.yml
@@ -99,8 +99,9 @@ relaynet-pong:
 
 redis:
   fullnameOverride: redis
-  usePassword: false
-  cluster:
+  auth:
     enabled: false
-  persistence:
-    enabled: false
+  architecture: standalone
+  master:
+    persistence:
+      enabled: false

--- a/chart/values.dev.yml
+++ b/chart/values.dev.yml
@@ -88,8 +88,6 @@ relaynet-pong:
   fullnameOverride: relaynet-pong
   pohttp_tls_required: false
   public_endpoint_address: relaynet-pong-pohttp.default
-  current_endpoint_key_id: "aGVsbG8K"
-  current_endpoint_session_key_id: "OTc1MzEK"
   vault:
     host: public-gateway-vault
     token: root


### PR DESCRIPTION
Because our old versions of Mongo and Redis are no longer available online.