### PR TITLE
chore: Test against MongoDB 4.4+

### DIFF
--- a/chart/dev-backing-services/values.yml
+++ b/chart/dev-backing-services/values.yml
@@ -26,6 +26,8 @@ minio:
 
 mongodb:
   fullnameOverride: mongodb
+  image:
+    tag: "4.4.15"
   auth:
     rootPassword: letmein
   persistence:

--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   mongodbMemoryServerOptions: {
     binary: {
-      version: '4.2.17',
+      version: '4.4.18',
       skipMD5: false,
     },
     instance: {},


### PR DESCRIPTION
Because we recently got an email from MongoDB Atlas saying that v4.2 will be automatically be upgraded to v4.4 in April.
