### PR TITLE
fix(deps): Upgrade cloud key store to get fix for GCP KMS timeouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.6.12",
-        "@relaycorp/awala-keystore-cloud": "^2.0.38",
+        "@relaycorp/awala-keystore-cloud": "^2.0.39",
         "@relaycorp/cogrpc": "^1.3.65",
         "@relaycorp/object-storage": "^1.4.62",
         "@relaycorp/pino-cloud": "^1.0.25",
@@ -1629,9 +1629,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@relaycorp/awala-keystore-cloud": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/@relaycorp/awala-keystore-cloud/-/awala-keystore-cloud-2.0.38.tgz",
-      "integrity": "sha512-1kZJNr4faZqDLD2fwtr5l6wjT5FeHzbx/rrN85u2C8hZQCq7L64G8xpBMjcuRXKSPiKIcRlGxCUMpEYvs6cg+g==",
+      "version": "2.0.39",
+      "resolved": "https://registry.npmjs.org/@relaycorp/awala-keystore-cloud/-/awala-keystore-cloud-2.0.39.tgz",
+      "integrity": "sha512-WwRNsoOWI/l5w6gTMSEbl7LO+/CU/5M6vu3Jgne7pGiff7Lt6jR9fZBKBrTQjobMq+vqeCL07ROCxT1mZse+8A==",
       "dependencies": {
         "@google-cloud/kms": "^3.2.0",
         "@relaycorp/relaynet-core": "< 2.0",
@@ -11860,9 +11860,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@relaycorp/awala-keystore-cloud": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/@relaycorp/awala-keystore-cloud/-/awala-keystore-cloud-2.0.38.tgz",
-      "integrity": "sha512-1kZJNr4faZqDLD2fwtr5l6wjT5FeHzbx/rrN85u2C8hZQCq7L64G8xpBMjcuRXKSPiKIcRlGxCUMpEYvs6cg+g==",
+      "version": "2.0.39",
+      "resolved": "https://registry.npmjs.org/@relaycorp/awala-keystore-cloud/-/awala-keystore-cloud-2.0.39.tgz",
+      "integrity": "sha512-WwRNsoOWI/l5w6gTMSEbl7LO+/CU/5M6vu3Jgne7pGiff7Lt6jR9fZBKBrTQjobMq+vqeCL07ROCxT1mZse+8A==",
       "requires": {
         "@google-cloud/kms": "^3.2.0",
         "@relaycorp/relaynet-core": "< 2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.6.12",
-    "@relaycorp/awala-keystore-cloud": "^2.0.38",
+    "@relaycorp/awala-keystore-cloud": "^2.0.39",
     "@relaycorp/cogrpc": "^1.3.65",
     "@relaycorp/object-storage": "^1.4.62",
     "@relaycorp/pino-cloud": "^1.0.25",


### PR DESCRIPTION
https://github.com/relaycorp/awala-keystore-cloud-js/pull/133
