### PR TITLE
fix(PoWeb): Reliably handle failure to establish NATS subscription

### DIFF
--- a/src/backingServices/natsStreaming.ts
+++ b/src/backingServices/natsStreaming.ts
@@ -91,7 +91,6 @@ export class NatsStreamingClient {
     const messagesStream = new PassThrough({ objectMode: true });
 
     const subscription = connection.subscribe(channel, queue, subscriptionOptions);
-    subscription.once('closed', () => messagesStream.destroy());
     subscription.on('message', (msg) => messagesStream.write(msg));
     await waitForSubscriptionToBeReady(subscription, connection, channel);
 


### PR DESCRIPTION
https://console.cloud.google.com/errors/detail/CKWyz6z_1d2GsAE?project=gw-frankfurt-4065

```
 NatsStreamingSubscriptionError: Subscription for queue consumer failed: too many subscriptions per channel
    at Subscription.<anonymous> (/opt/gw/build/main/backingServices/natsStreaming.js:74:68)
    at Subscription.emit (node:events:513:28)
    at Subscription.emit (node:domain:489:12)
    at Object.callback (/opt/gw/node_modules/node-nats-streaming/lib/stan.js:708:14)
    at Object.callback (/opt/gw/node_modules/nats/lib/nats.js:2045:16)
    at Client.processMsg (/opt/gw/node_modules/nats/lib/nats.js:1437:13)
    at Client.processInbound (/opt/gw/node_modules/nats/lib/nats.js:1310:14)
    at Socket.<anonymous> (/opt/gw/node_modules/nats/lib/nats.js:820:10)
    at Socket.emit (node:events:513:28)
    at Socket.emit (node:domain:489:12) 
```

See https://github.com/relaycorp/relaynet-internet-gateway/issues/567